### PR TITLE
update urls for defi sdk

### DIFF
--- a/src/pages/atomicdex/api/v20-dev/index.mdx
+++ b/src/pages/atomicdex/api/v20-dev/index.mdx
@@ -3,7 +3,7 @@ export const description = "AtomicDEX API now supports mmrpc 2.0 protocol format
 
 # AtomicDEX API RPC Protocol v2.0 (Dev)
 
-Starting with version [beta-2.1.3434](https://github.com/KomodoPlatform/atomicDEX-API/releases/tag/beta-2.1.3434), the AtomicDEX API supports the standardized protocol format called `mmrpc 2.0`.
+Starting with version [beta-2.1.3434](https://github.com/KomodoPlatform/komodo-defi-framework/releases/tag/beta-2.1.3434), the AtomicDEX API supports the standardized protocol format called `mmrpc 2.0`.
 
 It includes a uniform request, successful and error response formats. At the moment, only a few RPC methods support the `mmrpc 2.0` protocol.
 

--- a/src/pages/atomicdex/api/v20/message_signing/index.mdx
+++ b/src/pages/atomicdex/api/v20/message_signing/index.mdx
@@ -4,7 +4,7 @@ export const description = "The methods in this document allow you to sign and v
 # Signing_and_Verifying_Messages
 
 Cryptographically signed messages are a useful feature which can be used to [prove ownership of an address](https://www.coindesk.com/policy/2020/05/25/craig-wright-called-fraud-in-message-signed-with-bitcoin-addresses-he-claims-to-own/).
-If your [`coins`](https://github.com/KomodoPlatform/coins) file contains the correct [message prefix](https://bitcoin.stackexchange.com/questions/77324/how-are-bitcoin-signed-messages-generated/77325#77325) definitions for a coin, you can sign messages with the AtomicDEX-API(https://github.com/KomodoPlatform/atomicDEX-API). This can generally be found [within a coin's github repository](https://github.com/KomodoPlatform/komodo/blob/master/src/main.cpp#L146) and is assigned via the `sign_message_prefix` value as below.
+If your [`coins`](https://github.com/KomodoPlatform/coins) file contains the correct [message prefix](https://bitcoin.stackexchange.com/questions/77324/how-are-bitcoin-signed-messages-generated/77325#77325) definitions for a coin, you can sign messages with the AtomicDEX-API(https://github.com/KomodoPlatform/komodo-defi-framework). This can generally be found [within a coin's github repository](https://github.com/KomodoPlatform/komodo/blob/master/src/main.cpp#L146) and is assigned via the `sign_message_prefix` value as below.
 
 ```json
 {

--- a/src/pages/atomicdex/setup/configure-mm2-json/index.mdx
+++ b/src/pages/atomicdex/setup/configure-mm2-json/index.mdx
@@ -3,7 +3,7 @@ export const description = "Configure and activate coins on AtomicDEX API using 
 
 # AtomicDEX API configuration
 
-AtomicDEX-API configuration parameters are [listed in the source code](https://github.com/KomodoPlatform/atomicDEX-API/blob/mm2.1/mm2src/mm2.rs#L126), along with [additional runtime flags](https://github.com/KomodoPlatform/atomicDEX-API/blob/mm2.1/mm2src/mm2.rs#L115), and [per-process environment variables](https://github.com/KomodoPlatform/atomicDEX-API/blob/mm2.1/mm2src/mm2.rs#L171)
+AtomicDEX-API configuration parameters are [listed in the source code](https://github.com/KomodoPlatform/komodo-defi-framework/blob/mm2.1/mm2src/mm2.rs#L126), along with [additional runtime flags](https://github.com/KomodoPlatform/komodo-defi-framework/blob/mm2.1/mm2src/mm2.rs#L115), and [per-process environment variables](https://github.com/KomodoPlatform/komodo-defi-framework/blob/mm2.1/mm2src/mm2.rs#L171)
 
 ## MM2.json
 

--- a/src/pages/atomicdex/setup/index.mdx
+++ b/src/pages/atomicdex/setup/index.mdx
@@ -18,7 +18,7 @@ import rustupMinimal from "@/images/setup/rustup-minimal.png";
 <Note type="warning">
   If you would prefer to avoid building the AtomicDEX API from source, you can
   download our pre-built binary [from our Github releases
-  page.](https://github.com/KomodoPlatform/atomicDEX-API/releases)
+  page.](https://github.com/KomodoPlatform/komodo-defi-framework/releases)
 </Note>
 
 ### Note about Linux
@@ -148,7 +148,7 @@ Clone the AtomicDEX API repository:
 
 ```bash
 cd ~
-git clone https://github.com/KomodoPlatform/atomicDEX-API --branch mm2.1 --single-branch && cd atomicDEX-API
+git clone https://github.com/KomodoPlatform/komodo-defi-framework --branch mm2.1 --single-branch && cd atomicDEX-API
 ```
 
 Compile the source code.

--- a/src/pages/atomicdex/tutorials/how-to-become-a-liquidity-provider/index.mdx
+++ b/src/pages/atomicdex/tutorials/how-to-become-a-liquidity-provider/index.mdx
@@ -33,14 +33,14 @@ You can get the AtomicDEX API binary by downloading pre-compiled versions from t
 
 We will create `~/atomicDEX-API/target/debug` directory for compatibility with building from source method.
 
-You can get the latest release of the AtomicDEX API binary from the [atomicDEX-API/releases](https://github.com/KomodoPlatform/atomicDEX-API/releases) page on Github. Download and extract it to `~/atomicDEX-API/target/debug`.
+You can get the latest release of the AtomicDEX API binary from the [atomicDEX-API/releases](https://github.com/KomodoPlatform/komodo-defi-framework/releases) page on Github. Download and extract it to `~/atomicDEX-API/target/debug`.
 
 For example:
 
 ```bash
 mkdir -p ~/atomicDEX-API/target/debug
 cd ~/atomicDEX-API/target/debug
-wget https://github.com/KomodoPlatform/atomicDEX-API/releases/download/beta-2.1.4315/mm2-9fe6e9402-Linux-Release.zip
+wget https://github.com/KomodoPlatform/komodo-defi-framework/releases/download/beta-2.1.4315/mm2-9fe6e9402-Linux-Release.zip
 unzip mm2-9fe6e9402-Linux-Release.zip
 ```
 

--- a/src/pages/atomicdex/tutorials/how-to-compile-mm2-from-source/index.mdx
+++ b/src/pages/atomicdex/tutorials/how-to-compile-mm2-from-source/index.mdx
@@ -216,13 +216,13 @@ info: installing component 'rustfmt'
 #### Step 1: Download source code
 
 ```bash
-cd ~ ; git clone https://github.com/KomodoPlatform/atomicDEX-API --branch mm2.1 --single-branch && cd atomicDEX-API
+cd ~ ; git clone https://github.com/KomodoPlatform/komodo-defi-framework --branch mm2.1 --single-branch && cd atomicDEX-API
 ```
 
 <CollapsibleSection expandedText='Hide sample output' collapsedText='Show sample output'>
 
 ```
-$cd ~ ; git clone https://github.com/KomodoPlatform/atomicDEX-API --branch mm2.1 --single-branch && cd atomicDEX-API
+$cd ~ ; git clone https://github.com/KomodoPlatform/komodo-defi-framework --branch mm2.1 --single-branch && cd atomicDEX-API
 Cloning into 'atomicDEX-API'...
 remote: Enumerating objects: 34, done.
 remote: Counting objects: 100% (34/34), done.

--- a/src/pages/atomicdex/tutorials/listing-a-coin-on-atomicdex/index.mdx
+++ b/src/pages/atomicdex/tutorials/listing-a-coin-on-atomicdex/index.mdx
@@ -369,7 +369,7 @@ For Trezor compatibility, this field is required. You can find this value at [ht
 
 ## 8. Successful swap confirmation
 
-The coin must have participated in a successful Atomic Swap using [AtomicDEX-API](https://github.com/KomodoPlatform/atomicDEX-API/)
+The coin must have participated in a successful Atomic Swap using [AtomicDEX-API](https://github.com/KomodoPlatform/komodo-defi-framework/)
 
 When submitting your coin addition request, please submit the URLs of the 5 transactions (`takerfee sent`, `maker payment`, `taker payment` and `taker payment spent`, `maker payment spent`) produced by successful swap in a new file inside the [swaps directory](swaps)- here's an [example for KMD-ETH](https://github.com/KomodoPlatform/coins/blob/master/swaps/KMD-ETH.md). This means that, before going through the further steps and submitting the information to this coins database repo, you would have performed a successful atomic swap. The further steps explain the expected files/values to be submitted.
 

--- a/src/pages/start-here/about-komodo-platform/simple-installations/index.mdx
+++ b/src/pages/start-here/about-komodo-platform/simple-installations/index.mdx
@@ -35,7 +35,7 @@ Please see the full [Smart Chains](/smart-chains/) technical documentation for f
 
 ### Installing AtomicDEX Software
 
-The following links contain downloadable AtomicDEX software. Simply download the files appropriate for your operating system, extract them to your desired location, and double click the application to begin. [<b>Link to AtomicDEX Software - Simple Installations</b>](https://github.com/KomodoPlatform/atomicDEX-API/releases)
+The following links contain downloadable AtomicDEX software. Simply download the files appropriate for your operating system, extract them to your desired location, and double click the application to begin. [<b>Link to AtomicDEX Software - Simple Installations</b>](https://github.com/KomodoPlatform/komodo-defi-framework/releases)
 
 ### Using the official Docker image
 

--- a/src/pages/start-here/core-technology-discussions/initial-dex-offering/index.mdx
+++ b/src/pages/start-here/core-technology-discussions/initial-dex-offering/index.mdx
@@ -243,14 +243,14 @@ At this point, let us assume that the Entrepreneur has created their coin using 
 - The entrepreneur can fork the [AtomicDEX Desktop repository](https://github.com/KomodoPlatform/atomicDEX-Desktop) and add their coin/token to the GUI.
 - This modified software will be used both by the entrepreneur to place sell orders and by the purchasers to buy.
 - This method needs the entrepreneur to launch electrum servers for their coin if it is a Komodo Smart Chain or another UTXO type blockchain. The entrepreneur will need server software that supports lite wallets if their coin is an ETH or QTUM fork/clone.
-- The entrepreneur must also launch [AtomicDEX-API](https://github.com/KomodoPlatform/atomicDEX-API) on a server to act as a seed node for the trading pairs they are planning to support.
+- The entrepreneur must also launch [AtomicDEX-API](https://github.com/KomodoPlatform/komodo-defi-framework) on a server to act as a seed node for the trading pairs they are planning to support.
 
 ##### A Slightly more Involved Method
 
 - The entrepreneur can fork the [AtomicDEX Desktop repository](https://github.com/KomodoPlatform/atomicDEX-Desktop) or start from scratch. They create a custom IDO GUI with the specific features needed to conduct an IDO and only add the coins/tokens involved in their IDO.
 - This method allows the entrepreneur to create an exclusive feel to their IDO and remove distractions. This GUI is developed for the IDO and will only be used for it.
 - This method also needs the entrepreneur to launch electrum servers for their coin if it is a Komodo Smart Chain or another UTXO type blockchain. And server software that supports lite wallets if their coin is a ETH or QTUM fork/clone.
-- The entrepreneur must also launch [AtomicDEX-API](https://github.com/KomodoPlatform/atomicDEX-API) on a server to act as a seed node for the trading pairs they are planning to support.
+- The entrepreneur must also launch [AtomicDEX-API](https://github.com/KomodoPlatform/komodo-defi-framework) on a server to act as a seed node for the trading pairs they are planning to support.
 
 ##### Easy method, be Featured on AtomicDEX
 


### PR DESCRIPTION
@gcharang we currently also use the `atomicdex` name in the folder paths of this repo. How difficult would it be to change those?