### PR TITLE
Pin actions runner to Ubuntu 22.04

### DIFF
--- a/.github/workflows/get_data_lint_files_deploy.yml
+++ b/.github/workflows/get_data_lint_files_deploy.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   pre_job:
     # continue-on-error: true # Uncomment once integration is finished
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # Map a step output to a job output
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
@@ -25,7 +25,7 @@ jobs:
   update_lint_get_data:
     needs: pre_job
     if: needs.pre_job.outputs.should_skip != 'true' && startsWith(github.head_ref, 'lint-fix-patches') == false && github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
GHA workflow was using `ubuntu-latest`, which was updated from 22.04 to 24.04 three weeks ago - https://github.com/actions/runner-images/pull/11332

This led to a failing apt install for `libgconf-2-4`. 

This PR pins the actions runner image version to 22.04, which should resolve the apt package issue.