### PR TITLE
update kdf: seednodes - optional -> required

### DIFF
--- a/src/pages/komodo-defi-framework/api/common_structures/orders/index.mdx
+++ b/src/pages/komodo-defi-framework/api/common_structures/orders/index.mdx
@@ -253,7 +253,7 @@ export const description = "Each order on the Komodo Defi oderbook can be querie
 | pubkey                      | string           | The pubkey of the offer provider                                                                                                                    |
 | age                         | number           | The age of the offer (in seconds)                                                                                                                   |
 | zcredits                    | number           | The zeroconf deposit amount (deprecated)                                                                                                            |
-| netid                       | number           | The id of the network on which the request is made (default is `0`)                                                                                 |
+| netid                       | number           | The id of the network on which the request is made                                                                                                  |
 | uuid                        | string           | The uuid of order                                                                                                                                   |
 | is\_mine                    | bool             | Whether the order is placed by me                                                                                                                   |
 | base\_max\_volume           | string (decimal) | The maximum amount of `base` coin the offer provider is willing to buy or sell                                                                      |

--- a/src/pages/komodo-defi-framework/api/legacy/orderbook/index.mdx
+++ b/src/pages/komodo-defi-framework/api/legacy/orderbook/index.mdx
@@ -25,7 +25,7 @@ The `orderbook` method requests from the network the currently available orders 
 | base                             | string           | the name of the coin the user desires to receive                                                                                              |
 | rel                              | string           | the name of the coin the user will trade                                                                                                      |
 | timestamp                        | number           | the timestamp of the orderbook request                                                                                                        |
-| netid                            | number           | the id of the network on which the request is made (default is `0`)                                                                           |
+| netid                            | number           | the id of the network on which the request is made                                                                                            |
 | total\_asks\_base\_vol           | string (decimal) | the base volumes sum of all asks                                                                                                              |
 | total\_asks\_base\_vol\_rat      | rational         | the `total_asks_base_vol` represented as a standard [RationalValue](/komodo-defi-framework/api/common_structures/#rational-value) object.     |
 | total\_asks\_base\_vol\_fraction | fraction         | the `total_asks_base_vol` represented as a standard [FractionalValue](/komodo-defi-framework/api/common_structures/#fractional-value) object. |

--- a/src/pages/komodo-defi-framework/api/v20/swaps_and_orders/orderbook/index.mdx
+++ b/src/pages/komodo-defi-framework/api/v20/swaps_and_orders/orderbook/index.mdx
@@ -22,7 +22,7 @@ The v2 `orderbook` method requests from the network the currently available orde
 | rel                    | string           | The name of the coin the user will trade                                                                                                   |
 | numasks                | integer          | The number of outstanding asks                                                                                                             |
 | numbids                | integer          | The number of outstanding bids                                                                                                             |
-| netid                  | integer          | The id of the network on which the request is made (default is `8762`)                                                                     |
+| netid                  | integer          | The id of the network on which the request is made                                                                                         |
 | asks                   | array of objects | An array of standard [OrderDataV2](/komodo-defi-framework/api/common_structures/orders/#order-data-v2) objects containing outstanding asks |
 | bids                   | array of objects | An array of standard [OrderDataV2](/komodo-defi-framework/api/common_structures/orders/#order-data-v2) objects containing outstanding bids |
 | timestamp              | integer          | A UNIX timestamp representing when the orderbook was requested                                                                             |

--- a/src/pages/komodo-defi-framework/api/v20/wallet/fee_management/index.mdx
+++ b/src/pages/komodo-defi-framework/api/v20/wallet/fee_management/index.mdx
@@ -77,6 +77,7 @@ If `gas_fee_estimator` is set to `provider`, you'll also need to add the `gas_ap
 ```json
 {
     "netid": 8762,
+    "seednodes": ["46.4.87.18"],
     "rpcport": 8777,
     ...
     "gas_api": {

--- a/src/pages/komodo-defi-framework/setup/configure-mm2-json/index.mdx
+++ b/src/pages/komodo-defi-framework/setup/configure-mm2-json/index.mdx
@@ -23,7 +23,7 @@ When running the Komodo DeFi API via commandline with the `kdf` binary, some bas
 | rpcport                      | integer         | Optional, defaults to `7783`. Port to use for RPC communication. If set to `0`, an available port will be chosen randomly.                                                                                                                                                                                                                                                                                                            |
 | rpc\_local\_only             | boolean         | Optional, defaults to `true`. If `false` the Komodo DeFi Framework API will allow rpc methods sent from external IP addresses. **Warning:** Only use this if you know what you are doing, and have put the appropriate security measures in place.                                                                                                                                                                                    |
 | i\_am\_seed                  | boolean         | Optional, defaults to `false`. Runs Komodo DeFi Framework API as a seed node mode (acting as a relay for Komodo DeFi Framework API clients). Use of this mode is not reccomended on the main network (8762) as it could result in a pubkey ban if non-compliant. On alternative testing or private networks, at least one seed node is required to relay information to other Komodo DeFi Framework API clients using the same netID. |
-| seednodes                    | list of strings | Optional. If operating on a test or private netID, the IP address of at least one seed node is required (on the main network, these are already hardcoded)                                                                                                                                                                                                                                                                            |
+| seednodes                    | list of strings | The domain or IP address of at least one seed node running on the same `netid` is required for peer discovery, orderbook propagation and transmitting swap events.                                                                                                                                                                                                                                                                    |
 | enable\_hd                   | boolean         | Optional. If `true`, the Komodo DeFi-API will work in only the [HD mode](/komodo-defi-framework/api/v20/wallet/hd/), and coins will need to have a coin derivation path entry in the `coins` file for activation. Defaults to `false`.                                                                                                                                                                                                |
 | gas\_api                     | object          | Optional, Used for [EVM gas fee management](/komodo-defi-framework/api/v20/wallet/fee_management/). Contains fields for `provider` and `url` to source third party fee market information.                                                                                                                                                                                                                                            |
 | message\_service\_cfg        | object          | Optional. This data is used to configure [Telegram](https://telegram.org/) messenger alerts for swap events when running using the [makerbot functionality](/komodo-defi-framework/api/v20/swaps_and_orders/start_simple_market_maker_bot/). For more information check out the [telegram alerts guide](/komodo-defi-framework/api/v20/utils/telegram_alerts/)                                                                        |
@@ -47,6 +47,7 @@ When running the Komodo DeFi API via commandline with the `kdf` binary, some bas
 {
   "gui": "DEVDOCS_CLI",
   "netid": 8762,
+  "seednodes": ["46.4.87.18"],
   "rpc_password": "ENTER_UNIQUE_PASSWORD",
   "passphrase": "ENTER_UNIQUE_SEED_PHRASE_DONT_USE_THIS_CHANGE_IT_OR_FUNDS_NOT_SAFU",
   "allow_weak_password": true,
@@ -60,6 +61,7 @@ When running the Komodo DeFi API via commandline with the `kdf` binary, some bas
 {
   "gui": "DEVDOCS_CLI",
   "netid": 8762,
+  "seednodes": ["46.4.87.18"],
   "rpc_password": "Ent3r_Un1Qu3_Pa$$w0rd",
   "passphrase": "ENTER_UNIQUE_SEED_PHRASE_DONT_USE_THIS_CHANGE_IT_OR_FUNDS_NOT_SAFU",
   "allow_weak_password": false,
@@ -73,6 +75,7 @@ When running the Komodo DeFi API via commandline with the `kdf` binary, some bas
 {
   "gui": "DEVDOCS_CLI",
   "netid": 8762,
+  "seednodes": ["46.4.87.18"],
   "rpc_password": "Ent3r_Un1Qu3_Pa$$w0rd",
   "passphrase": "ENTER_UNIQUE_SEED_PHRASE_DONT_USE_THIS_CHANGE_IT_OR_FUNDS_NOT_SAFU",
   "gas_api": {
@@ -88,6 +91,7 @@ When running the Komodo DeFi API via commandline with the `kdf` binary, some bas
 {
   "gui": "DEVDOCS_CLI",
   "netid": 8762,
+  "seednodes": ["46.4.87.18"],
   "rpc_password": "Ent3r_Un1Qu3_Pa$$w0rd",
   "passphrase": "ENTER_UNIQUE_SEED_PHRASE_DONT_USE_THIS_CHANGE_IT_OR_FUNDS_NOT_SAFU",
   "wss_certs": {
@@ -104,6 +108,7 @@ When running the Komodo DeFi API via commandline with the `kdf` binary, some bas
 {
   "gui": "DEVDOCS_CLI",
   "netid": 8762,
+  "seednodes": ["46.4.87.18"],
   "rpc_password": "Ent3r_Un1Qu3_Pa$$w0rd",
   "wallet_name": "Gringotts Retirement Fund",
   "wallet_password": "Q^wJZg~Ck3.tPW~asnM-WrL"
@@ -116,6 +121,7 @@ When running the Komodo DeFi API via commandline with the `kdf` binary, some bas
 {
   "gui": "DEVDOCS_CLI",
   "netid": 8762,
+  "seednodes": ["46.4.87.18"],
   "rpc_password": "Ent3r_Un1Qu3_Pa$$w0rd",
   "1inch_api": "https://api.1inch.dev"
 }
@@ -145,6 +151,7 @@ If you are using HD wallets, you will need to set `enable_hd` to `true` in to yo
 {
   "gui": "DEVDOCS_CLI",
   "netid": 8762,
+  "seednodes": ["46.4.87.18"],
   "rpc_password": "Ent3r_Un1Qu3_Pa$$w0rd",
   "passphrase": "ENTER_UNIQUE_SEED_PHRASE_DONT_USE_THIS_CHANGE_IT_OR_FUNDS_NOT_SAFU",
   "allow_weak_password": false,

--- a/src/pages/komodo-defi-framework/tutorials/api-docker-telegram/index.mdx
+++ b/src/pages/komodo-defi-framework/tutorials/api-docker-telegram/index.mdx
@@ -136,7 +136,7 @@ start.sh
 
 <CollapsibleSection expandedText="Hide Output" collapsedText="Show Output">
   ```bash
-   root        30 17.5  3.8 879940 154996 pts/0   Sl+  10:09   0:00 /usr/local/bin/kdf {"gui":"MM2GUI","netid":9999, "userhome":"/root", "passphrase":"L1XXXXXXXXXXXXXXXXXXXRY", "rpc_password":"HlXXXXXXXKW"}
+   root        30 17.5  3.8 879940 154996 pts/0   Sl+  10:09   0:00 /usr/local/bin/kdf {"gui":"MM2GUI","netid":8762, "seednodes": ["46.4.87.18"], "userhome":"/root", "passphrase":"L1XXXXXXXXXXXXXXXXXXXRY", "rpc_password":"HlXXXXXXXKW"}
   ```
 </CollapsibleSection>
 

--- a/src/pages/komodo-defi-framework/tutorials/api-walkthrough/index.mdx
+++ b/src/pages/komodo-defi-framework/tutorials/api-walkthrough/index.mdx
@@ -73,12 +73,13 @@ We also need to create an MM2.json file in the same directory as the `coins` fil
 
 ### MM2.json Minimal Configuration
 
-| Parameter     | Type    | Description                                                                                                                                                                                                                       |
-| ------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| gui           | string  | Information to identify which app, tool or product is using the API, e.g. `KomodoWallet iOS 1.0.1`. Helps developers identify if an issue is related to specific builds or operating systems etc.                                 |
-| netid         | integer | Nework ID number, telling the Komodo DeFi Framework API which network to join. 8762 is the current main network, though alternative netids can be used for testing or "private" trades as long as seed nodes exist to support it. |
-| passphrase    | string  | Your passphrase; this is the source of each of your coins private keys. KEEP IT SAFE!                                                                                                                                             |
-| rpc\_password | string  | For RPC requests that need authentication, this will need to match the `userpass` value in the request body.                                                                                                                      |
+| Parameter     | Type            | Description                                                                                                                                                                                       |
+| ------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| gui           | string          | Information to identify which app, tool or product is using the API, e.g. `KomodoWallet iOS 1.0.1`. Helps developers identify if an issue is related to specific builds or operating systems etc. |
+| netid         | integer         | Nework ID number, telling the Komodo DeFi Framework API which network to join. At least one seed node domain or IP address needs to be specified on the same `netid` to support it.               |
+| seednodes     | list of strings | The domain or IP address of at least one seed node running on the same `netid` is required for peer discovery, orderbook propagation and transmitting swap events.                                |
+| passphrase    | string          | Your passphrase; this is the source of each of your coins private keys. KEEP IT SAFE!                                                                                                             |
+| rpc\_password | string          | For RPC requests that need authentication, this will need to match the `userpass` value in the request body.                                                                                      |
 
 <Note>
   Unless you include the `allow_weak_password` paramater and set it to `true`, your `rpc_password`:
@@ -92,7 +93,7 @@ We also need to create an MM2.json file in the same directory as the `coins` fil
 The MM2.json configuration commands can also be supplied at runtime, as below:
 
 ```bash
-stdbuf -oL ./kdf "{\"gui\":\"Docs_Walkthru\",\"netid\":8762, \"passphrase\":\"YOUR_PASSPHRASE_HERE\", \"rpc_password\":\"YOUR_PASSWORD_HERE\"}" &
+stdbuf -oL ./kdf "{\"gui\":\"Docs_Walkthru\",\"netid\":8762, "seednodes": ["46.4.87.18"], \"passphrase\":\"YOUR_PASSPHRASE_HERE\", \"rpc_password\":\"YOUR_PASSWORD_HERE\"}" &
 ```
 
 Replace `YOUR_PASSPHRASE_HERE` and `YOUR_PASSWORD_HERE` with your actual passphrase and password, and then execute the command in the terminal.
@@ -137,7 +138,7 @@ If you see something similar, the Komodo DeFi Framework API is up and running!
   When using the Komodo DeFi Framework API on a VPS without accompanying tools such as `tmux` or `screen`, it is recommended to use [`nohup`](https://www.digitalocean.com/community/tutorials/nohup-command-in-linux). This will ensure that the Komodo DeFi Framework API instance is not shutdown when the user logs out.
 
   ```bash
-  stdbuf -oL nohup ./mm2 "{\"gui\":\"Docs_Walkthru\",\"netid\":8762, \"passphrase\":\"YOUR_PASSPHRASE_HERE\", \"rpc_password\":\"YOUR_PASSWORD_HERE\"}" &
+  stdbuf -oL nohup ./mm2 "{\"gui\":\"Docs_Walkthru\",\"netid\":8762, "seednodes": ["46.4.87.18"], \"passphrase\":\"YOUR_PASSPHRASE_HERE\", \"rpc_password\":\"YOUR_PASSWORD_HERE\"}" &
   ```
 </Note>
 

--- a/src/pages/komodo-defi-framework/tutorials/setup-komodefi-api-aws/index.mdx
+++ b/src/pages/komodo-defi-framework/tutorials/setup-komodefi-api-aws/index.mdx
@@ -19,7 +19,7 @@ apt-get install -y unzip jq curl
 wget $(curl --silent https://api.github.com/repos/KomodoPlatform/komodo-defi-framework/releases | jq -r '.[0].assets[] | select(.name | endswith("Linux-Release.zip")).browser_download_url')
 wget https://raw.githubusercontent.com/KomodoPlatform/coins/master/coins
 unzip *Linux-Release.zip
-./kdf "{\"netid\":8762,\"gui\":\"aws_cli\",\"passphrase\":\"SEED_WORDS_PLEASE_REPLACE\",\"rpc_password\":\"RPC_PASS_PLEASE_REPLACE\",\"myipaddr\":\"0.0.0.0\"}"
+./kdf "{\"netid\":8762,\"seednodes\":[\"46.4.87.18\"],\"gui\":\"aws_cli\",\"passphrase\":\"SEED_WORDS_PLEASE_REPLACE\",\"rpc_password\":\"RPC_PASS_PLEASE_REPLACE\",\"myipaddr\":\"0.0.0.0\"}"
 ```
 
 ## Install AWS CLI , get AWS access credentials


### PR DESCRIPTION
Closes https://github.com/KomodoPlatform/komodo-docs-mdx/issues/483
Related KDF PR: https://github.com/KomodoPlatform/komodo-defi-framework/pull/2439

To test:
1. Attempt to launch KDF without specifying seednode param in MM2.json. It should fail.
2. Add seednode param to MM2.json, and launch KDF. It should function as expected.
