### PR TITLE
Fix `data` param position

### DIFF
--- a/src/pages/komodo-defi-framework/api/legacy/unban_pubkeys/index.mdx
+++ b/src/pages/komodo-defi-framework/api/legacy/unban_pubkeys/index.mdx
@@ -70,12 +70,12 @@ The `unban_pubkeys` method will remove all currently banned pubkeys from your ba
     "userpass": "RPC_UserP@SSW0RD",
     "method": "unban_pubkeys",
     "unban_by": {
-      "type": "Few"
-    },
-    "data": [
-      "2cd3021a2197361fb70b862c412bc8e44cff6951fa1de45ceabfdd9b4c520420",
-      "2cd3021a2197361fb70b862c412bc8e44cff6951fa1de45ceabfdd9b4c520422"
-    ]
+      "type": "Few",
+      "data": [
+        "2cd3021a2197361fb70b862c412bc8e44cff6951fa1de45ceabfdd9b4c520420",
+        "2cd3021a2197361fb70b862c412bc8e44cff6951fa1de45ceabfdd9b4c520422"
+      ]
+    }
   }
   ```
 </CodeGroup>


### PR DESCRIPTION
One of the `unban_pubkeys` method examples was detected as invalid by a scan run in https://github.com/KomodoPlatform/komodo-docs-mdx/pull/511, due to [incorrect `data` param position](https://dev.komodo-docs.pages.dev/en/docs/komodo-defi-framework/api/legacy/unban_pubkeys/#command-2). 

This PR fixes the example.
