### PR TITLE
fix OrderDataV2 link for best_orders

### DIFF
--- a/src/pages/komodo-defi-framework/api/v20/swaps_and_orders/best_orders/index.mdx
+++ b/src/pages/komodo-defi-framework/api/v20/swaps_and_orders/best_orders/index.mdx
@@ -26,8 +26,8 @@ For coins with segwit, they may appear twice in the output (once for each addres
 
 | Structure         | Type          | Description                                                                                                                |
 | ----------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| orders            | object (map)  | the `ticker -> array of standard [OrderData](/komodo-defi-framework/api/common_structures/orders/#order-data) objects` map |
-| original\_tickers | list (string) | Tickers included in response when `orderbook_ticker` is configured for the queried coin in `coins` file                    |
+| orders            | object (map)  | Map of the `ticker` -> array of standard [OrderDataV2](https://komodoplatform.com/en/docs/komodo-defi-framework/api/common_structures/orders/#order-data-v2) objects, where the `ticker` denotes the other coin of the trading pair. |
+| original\_tickers | list (string) | Tickers included in response when `orderbook_ticker` is configured for the queried coin in `coins` file.                   |
 
 #### 📌 Examples
 


### PR DESCRIPTION
Fixes the link to OrderDataV2 (currently escaped by backticks) in the best_order RPC.
Also suggests a fix to the description for the RPC response.