### PR TITLE
docs: update default netid to 6133 and dex fee to 2%

### DIFF
--- a/src/pages/komodo-defi-framework/api/legacy/buy/index.mdx
+++ b/src/pages/komodo-defi-framework/api/legacy/buy/index.mdx
@@ -8,7 +8,7 @@ export const description = "The buy method issues a buy request and attempts to 
 The `buy` method issues a buy request and attempts to match an order from the orderbook based on the provided arguments.
 
 <Note>
-  *   Buy and sell methods always create the `taker` order first. A `taker` order must pay a `dexfee` during the swap as it is taking liquidity from the market. The `dexfee` is calculated as "the greater of either `Minimum transaction amount (dust) TAKER COIN` or `0.0001 TAKER COIN` or `1/777th` the size of the desired order". If your `GoodTillCancelled` order is not matched in 30 seconds, the order is automatically converted to a `maker` request and stays on the orderbook until the request is matched or cancelled. To always act as a maker, please use the [setprice](/komodo-defi-framework/api/legacy/setprice/) method.
+  *   Buy and sell methods always create the `taker` order first. A `taker` order must pay a `dexfee` during the swap as it is taking liquidity from the market. The `dexfee` is calculated as "the greater of either `Minimum transaction amount (dust) TAKER COIN` or `0.0001 TAKER COIN` or `2%` of the desired order". If your `GoodTillCancelled` order is not matched in 30 seconds, the order is automatically converted to a `maker` request and stays on the orderbook until the request is matched or cancelled. To always act as a maker, please use the [setprice](/komodo-defi-framework/api/legacy/setprice/) method.
   *   To prevent a user from making trades in which the transaction fees may end up costing a significant portion of the value of the trade, we have set a lower limit to the value of a trade. See the description of the `volume` and `min_volume` arguments for more info.
 </Note>
 

--- a/src/pages/komodo-defi-framework/api/legacy/orderbook/index.mdx
+++ b/src/pages/komodo-defi-framework/api/legacy/orderbook/index.mdx
@@ -818,7 +818,7 @@ The `orderbook` method requests from the network the currently available orders 
         ]
       }
     ],
-    "netid": 8762,
+    "netid": 6133,
     "numasks": 2,
     "numbids": 6,
     "rel": "MARTY",

--- a/src/pages/komodo-defi-framework/api/legacy/sell/index.mdx
+++ b/src/pages/komodo-defi-framework/api/legacy/sell/index.mdx
@@ -8,7 +8,7 @@ export const description = "The sell method issues a sell request and attempts t
 The `sell` method issues a sell request and attempts to match an order from the orderbook based on the provided arguments.
 
 <Note>
-  *   Buy and sell methods always create the `taker` order first. A `taker` order must pay a `dexfee` during the swap as it is taking liquidity from the market. The `dexfee` is calculated as "the greater of either `Minimum transaction amount (dust) TAKER COIN` or `0.0001 TAKER COIN` or `1/777th` the size of the desired order". If your `GoodTillCancelled` order is not matched in 30 seconds, the order is automatically converted to a `maker` request and stays on the orderbook until the request is matched or cancelled. To always act as a maker, please use the [setprice](/komodo-defi-framework/api/legacy/setprice/) method.
+  *   Buy and sell methods always create the `taker` order first. A `taker` order must pay a `dexfee` during the swap as it is taking liquidity from the market. The `dexfee` is calculated as "the greater of either `Minimum transaction amount (dust) TAKER COIN` or `0.0001 TAKER COIN` or `2%` of the desired order". If your `GoodTillCancelled` order is not matched in 30 seconds, the order is automatically converted to a `maker` request and stays on the orderbook until the request is matched or cancelled. To always act as a maker, please use the [setprice](/komodo-defi-framework/api/legacy/setprice/) method.
   *   To prevent a user from making trades in which the transaction fees may end up costing a significant portion of the value of the trade, we have set a lower limit to the value of a trade. See the description of the `volume` argument for more info.
 </Note>
 

--- a/src/pages/komodo-defi-framework/api/v20/swaps_and_orders/orderbook/index.mdx
+++ b/src/pages/komodo-defi-framework/api/v20/swaps_and_orders/orderbook/index.mdx
@@ -248,7 +248,7 @@ The v2 `orderbook` method requests from the network the currently available orde
         }
         }
       ],
-      "net_id": 8762,
+      "net_id": 6133,
       "num_asks": 3,
       "num_bids": 3,
       "rel": "DASH",

--- a/src/pages/komodo-defi-framework/api/v20/wallet/fee_management/index.mdx
+++ b/src/pages/komodo-defi-framework/api/v20/wallet/fee_management/index.mdx
@@ -72,7 +72,7 @@ If `gas_fee_estimator` is set to `Provider`, you'll also need to add the `gas_ap
 
 ```json
 {
-    "netid": 8762,
+    "netid": 6133,
     "seednodes": ["seed01.kmdefi.net", "seed02.kmdefi.net"],
     "rpcport": 8777,
     ...

--- a/src/pages/komodo-defi-framework/setup/configure-mm2-json/index.mdx
+++ b/src/pages/komodo-defi-framework/setup/configure-mm2-json/index.mdx
@@ -23,13 +23,13 @@ When running the Komodo DeFi API via commandline with the `kdf` binary, some bas
 | gas\_api                        | object          | Optional, Used for [EVM gas fee management](/komodo-defi-framework/api/v20/wallet/fee_management/). Contains fields for `provider` and `url` to source third party fee market information.                                                                                                                                                                                                                                            |
 | gui                             | string          | Information to identify which app, tool or product is using the API, e.g. `KomodoWallet iOS 1.0.1`. Helps developers identify if an issue is related to specific builds or operating systems etc.                                                                                                                                                                                                                                     |
 | https                           | boolean         | Optional. Only used with wss. Defaults to `false`, set to `true` to allow TLS/SSL enabled RPC (e.g. remote queries to a domain with a valid SSL certificate).                                                                                                                                                                                                                                                                         |
-| i\_am\_seed                     | boolean         | Optional, defaults to `false`. Runs Komodo DeFi Framework API as a seed node mode (acting as a relay for Komodo DeFi Framework API clients). Use of this mode is not reccomended on the main network (8762) as it could result in a pubkey ban if non-compliant. On alternative testing or private networks, at least one seed node is required to relay information to other Komodo DeFi Framework API clients using the same netID. |
+| i\_am\_seed                     | boolean         | Optional, defaults to `false`. Runs Komodo DeFi Framework API as a seed node mode (acting as a relay for Komodo DeFi Framework API clients). Use of this mode is not reccomended on the main network (6133) as it could result in a pubkey ban if non-compliant. On alternative testing or private networks, at least one seed node is required to relay information to other Komodo DeFi Framework API clients using the same netID. |
 | is\_bootstrap\_node             | boolean         | Optional, defaults to `false`. If `true`, and `i_am_seed` is also true, KDF will act as a bootstrap node for the network.                                                                                                                                                                                                                                                                                                             |
 | is\_watcher                     | boolean         | Optional, defaults to `false`. If `true`, KDF will operate as a watcher seed nodes which may (in some cases) complete the final steps of a swap when a party goes offline.                                                                                                                                                                                                                                                            |
 | message\_service\_cfg           | object          | Optional. This data is used to configure [Telegram](https://telegram.org/) messenger alerts for swap events when running using the [makerbot functionality](/komodo-defi-framework/api/v20/swaps_and_orders/start_simple_market_maker_bot/). For more information check out the [telegram alerts guide](/komodo-defi-framework/setup/telegram-alerts/)                                                                                |
 | metrics                         | integer         | Optional, defaults to `300`. The interval in seconds which metrics are logged. Set to `0` to disable metrics.                                                                                                                                                                                                                                                                                                                         |
 | myipaddr                        | string          | Optional. IP address to bind to for P2P networking.                                                                                                                                                                                                                                                                                                                                                                                   |
-| netid                           | integer         | Nework ID number, telling the Komodo DeFi Framework  which network to join. 8762 is the current main network, though alternative netids can be used for testing or "private" trades as long as seed nodes exist to support it.                                                                                                                                                                                                        |
+| netid                           | integer         | Nework ID number, telling the Komodo DeFi Framework  which network to join. 6133 is the current main network, though alternative netids can be used for testing or "private" trades as long as seed nodes exist to support it.                                                                                                                                                                                                        |
 | p2p\_in\_memory                 | boolean         | Optional, defaults to `false`. Enables in-memory peer-to-peer (P2P) networking mode. When set to true, the application bypasses traditional seed nodes and sets up in-memory relay for P2P communication. This is typically used in testing or isolated environments where external P2P communication is not desired.                                                                                                                 |
 | p2p\_in\_memory\_port           | integer         | Optional (required when `p2p_in_memory` is `true`). Specifies the port number used by the in-memory relay node. This value is required if p2p\_in\_memory mode is active. It defines the local port for the relay to operate and accept in-memory peer connections.                                                                                                                                                                   |
 | passphrase                      | string          | Optional. Your passphrase (mnemonic phrase) in plain text. This is the source of each of your coins private keys. [**KEEP IT SAFE!**](https://www.youtube.com/watch?v=WFpxVbTqhB8). For more secure, encrypted storage in a local database, use the `wallet_name` and `wallet_password` parameters below.                                                                                                                             |
@@ -48,7 +48,7 @@ When running the Komodo DeFi API via commandline with the `kdf` binary, some bas
 | wss\_certs                      | object          | Optional. Contains fields for `server_priv_key` and `certificate` to allow RPC or P2P communications over TLS/SSL.                                                                                                                                                                                                                                                                                                                    |
 
 <Note>
-  A list of current seed nodes running on the `8762` netid can be sourced from [https://github.com/KomodoPlatform/coins/blob/master/seed-nodes.json](https://github.com/KomodoPlatform/coins/blob/master/seed-nodes.json)
+  A list of current seed nodes running on the `6133` netid can be sourced from [https://github.com/KomodoPlatform/coins/blob/master/seed-nodes.json](https://github.com/KomodoPlatform/coins/blob/master/seed-nodes.json)
   WASM nodes can only be run as a seed node when `p2p_in_memory` is `true`.
   In the 2.4.0-beta release of KDF, the `event_stream_configuration` has been renamed to `event_streaming_configuration` and no longer contains the `active_events` object. Rather than define the configuration for events in global config, a [suite of new RPC methods](/komodo-defi-framework/api/v20/streaming/) to define streaming has been added which allows for much greater control over which events to track.
 </Note>
@@ -58,7 +58,7 @@ When running the Komodo DeFi API via commandline with the `kdf` binary, some bas
 ```json
 {
   "gui": "DEVDOCS_CLI",
-  "netid": 8762,
+  "netid": 6133,
   "seednodes": ["seed01.kmdefi.net", "seed02.kmdefi.net"],
   "rpc_password": "ENTER_UNIQUE_PASSWORD",
   "passphrase": "ENTER_UNIQUE_SEED_PHRASE_DONT_USE_THIS_CHANGE_IT_OR_FUNDS_NOT_SAFU",
@@ -72,7 +72,7 @@ When running the Komodo DeFi API via commandline with the `kdf` binary, some bas
 ```json
 {
   "gui": "DEVDOCS_CLI",
-  "netid": 8762,
+  "netid": 6133,
   "seednodes": ["seed01.kmdefi.net", "seed02.kmdefi.net"],
   "rpc_password": "Ent3r_Un1Qu3_Pa$$w0rd",
   "passphrase": "ENTER_UNIQUE_SEED_PHRASE_DONT_USE_THIS_CHANGE_IT_OR_FUNDS_NOT_SAFU",
@@ -86,7 +86,7 @@ When running the Komodo DeFi API via commandline with the `kdf` binary, some bas
 ```json
 {
   "gui": "DEVDOCS_CLI",
-  "netid": 8762,
+  "netid": 6133,
   "seednodes": ["seed01.kmdefi.net", "seed02.kmdefi.net"],
   "rpc_password": "Ent3r_Un1Qu3_Pa$$w0rd",
   "passphrase": "ENTER_UNIQUE_SEED_PHRASE_DONT_USE_THIS_CHANGE_IT_OR_FUNDS_NOT_SAFU",
@@ -102,7 +102,7 @@ When running the Komodo DeFi API via commandline with the `kdf` binary, some bas
 ```json
 {
   "gui": "DEVDOCS_CLI",
-  "netid": 8762,
+  "netid": 6133,
   "seednodes": ["seed01.kmdefi.net", "seed02.kmdefi.net"],
   "rpc_password": "Ent3r_Un1Qu3_Pa$$w0rd",
   "passphrase": "ENTER_UNIQUE_SEED_PHRASE_DONT_USE_THIS_CHANGE_IT_OR_FUNDS_NOT_SAFU",
@@ -119,7 +119,7 @@ When running the Komodo DeFi API via commandline with the `kdf` binary, some bas
 ```json
 {
   "gui": "DEVDOCS_CLI",
-  "netid": 8762,
+  "netid": 6133,
   "seednodes": ["seed01.kmdefi.net", "seed02.kmdefi.net"],
   "rpc_password": "Ent3r_Un1Qu3_Pa$$w0rd",
   "wallet_name": "Gringotts Retirement Fund",
@@ -132,7 +132,7 @@ When running the Komodo DeFi API via commandline with the `kdf` binary, some bas
 ```json
 {
   "gui": "DEVDOCS_CLI",
-  "netid": 8762,
+  "netid": 6133,
   "seednodes": ["seed01.kmdefi.net", "seed02.kmdefi.net"],
   "rpc_password": "Ent3r_Un1Qu3_Pa$$w0rd",
   "1inch_api": "https://api.1inch.dev"
@@ -144,7 +144,7 @@ When running the Komodo DeFi API via commandline with the `kdf` binary, some bas
 ```json
 {
   "gui": "DEVDOCS_CLI",
-  "netid": 8762,
+  "netid": 6133,
   "rpc_password": "Ent3r_Un1Qu3_Pa$$w0rd"
   "event_streaming_configuration": {
       "access_control_allow_origin": "*",
@@ -176,7 +176,7 @@ If you are using HD wallets, you will need to set `enable_hd` to `true` in to yo
 ```json
 {
   "gui": "DEVDOCS_CLI",
-  "netid": 8762,
+  "netid": 6133,
   "seednodes": ["seed01.kmdefi.net", "seed02.kmdefi.net"],
   "rpc_password": "Ent3r_Un1Qu3_Pa$$w0rd",
   "passphrase": "ENTER_UNIQUE_SEED_PHRASE_DONT_USE_THIS_CHANGE_IT_OR_FUNDS_NOT_SAFU",
@@ -198,7 +198,7 @@ For bootstrap nodes:
 ```json
 {
   "gui": "DEVDOCS_CLI",
-  "netid": 8762,
+  "netid": 6133,
   "seednodes": ["seed01.kmdefi.net", "seed02.kmdefi.net"],
   "is_bootstrap_node": true,
   "i_am_seed": true,
@@ -216,7 +216,7 @@ For a normal seed node:
 ```json
 {
   "gui": "DEVDOCS_CLI",
-  "netid": 8762,
+  "netid": 6133,
   "seednodes": ["seed01.kmdefi.net", "seed02.kmdefi.net"],
   "is_bootstrap_node": false,
   "i_am_seed": true,

--- a/src/pages/komodo-defi-framework/setup/telegram-alerts/index.mdx
+++ b/src/pages/komodo-defi-framework/setup/telegram-alerts/index.mdx
@@ -12,7 +12,7 @@ To set this up, you can add some additional parameters to your MM2.json as shown
 ```json
 {
 	"gui": "MarketMakerBot",
-	"netid": 8762,
+	"netid": 6133,
 	"rpc_password": "YOUR_PASSWORD",
 	"passphrase": "YOUR SEED PHRASE",
 	"dbdir": "/path/to/your/komodefi/DB",

--- a/src/pages/komodo-defi-framework/tutorials/api-docker-telegram/index.mdx
+++ b/src/pages/komodo-defi-framework/tutorials/api-docker-telegram/index.mdx
@@ -136,7 +136,7 @@ start.sh
 
 <CollapsibleSection expandedText="Hide Output" collapsedText="Show Output">
   ```bash
-   root        30 17.5  3.8 879940 154996 pts/0   Sl+  10:09   0:00 /usr/local/bin/kdf {"gui":"MM2GUI","netid":8762, "seednodes": ["seed01.kmdefi.net", "seed02.kmdefi.net"], "userhome":"/root", "passphrase":"L1XXXXXXXXXXXXXXXXXXXRY", "rpc_password":"HlXXXXXXXKW"}
+   root        30 17.5  3.8 879940 154996 pts/0   Sl+  10:09   0:00 /usr/local/bin/kdf {"gui":"MM2GUI","netid":6133, "seednodes": ["seed01.kmdefi.net", "seed02.kmdefi.net"], "userhome":"/root", "passphrase":"L1XXXXXXXXXXXXXXXXXXXRY", "rpc_password":"HlXXXXXXXKW"}
   ```
 </CollapsibleSection>
 

--- a/src/pages/komodo-defi-framework/tutorials/api-walkthrough/index.mdx
+++ b/src/pages/komodo-defi-framework/tutorials/api-walkthrough/index.mdx
@@ -93,7 +93,7 @@ We also need to create an MM2.json file in the same directory as the `coins` fil
 The MM2.json configuration commands can also be supplied at runtime, as below:
 
 ```bash
-stdbuf -oL ./kdf "{\"gui\":\"Docs_Walkthru\",\"netid\":8762, "seednodes": ["seed01.kmdefi.net", "seed02.kmdefi.net"], \"passphrase\":\"YOUR_PASSPHRASE_HERE\", \"rpc_password\":\"YOUR_PASSWORD_HERE\"}" &
+stdbuf -oL ./kdf "{\"gui\":\"Docs_Walkthru\",\"netid\":6133, "seednodes": ["seed01.kmdefi.net", "seed02.kmdefi.net"], \"passphrase\":\"YOUR_PASSPHRASE_HERE\", \"rpc_password\":\"YOUR_PASSWORD_HERE\"}" &
 ```
 
 Replace `YOUR_PASSPHRASE_HERE` and `YOUR_PASSWORD_HERE` with your actual passphrase and password, and then execute the command in the terminal.
@@ -138,7 +138,7 @@ If you see something similar, the Komodo DeFi Framework API is up and running!
   When using the Komodo DeFi Framework API on a VPS without accompanying tools such as `tmux` or `screen`, it is recommended to use [`nohup`](https://www.digitalocean.com/community/tutorials/nohup-command-in-linux). This will ensure that the Komodo DeFi Framework API instance is not shutdown when the user logs out.
 
   ```bash
-  stdbuf -oL nohup ./kdf "{\"gui\":\"Docs_Walkthru\",\"netid\":8762, "seednodes": ["seed01.kmdefi.net", "seed02.kmdefi.net"]
+  stdbuf -oL nohup ./kdf "{\"gui\":\"Docs_Walkthru\",\"netid\":6133, "seednodes": ["seed01.kmdefi.net", "seed02.kmdefi.net"]
   , \"passphrase\":\"YOUR_PASSPHRASE_HERE\", \"rpc_password\":\"YOUR_PASSWORD_HERE\"}" &
   ```
 </Note>
@@ -303,7 +303,7 @@ The response below shows a list of users willing to send DOC in exchange for MAR
 
 <CollapsibleSection expandedText="Hide Response" collapsedText="Show Response">
   ```json
-  {"bids": [],"numbids": 0,"biddepth": 0,"asks": [{"coin": "DOC","address": "RJTYiYeJ8eVvJ53n2YbrVmxWNNMVZjDGLh","price": "0.89999998","price_rat": [[1, [813957463, 471859]],[1, [0, 524288]]],"price_fraction": {"numer": "2026619787280727","denom": "2251799813685248"},"maxvolume": "10855.85028615","max_volume_rat": [[1, [3593286463, 1389548]],[1, [0, 128]]],"max_volume_fraction": {"numer": "5968066809508671","denom": "549755813888"},"pubkey": "5a2f1c468b7083c4f7649bf68a50612ffe7c38b1d62e1ece3829ca88e7e7fd12","age": 5,"uuid": "5bff6021-b086-477e-b874-f45d898933fe","is_mine": false}],"numasks": 1,"askdepth": 0,"base": "DOC","rel": "MARTY","timestamp": 1549319941,"netid": 8762}
+  {"bids": [],"numbids": 0,"biddepth": 0,"asks": [{"coin": "DOC","address": "RJTYiYeJ8eVvJ53n2YbrVmxWNNMVZjDGLh","price": "0.89999998","price_rat": [[1, [813957463, 471859]],[1, [0, 524288]]],"price_fraction": {"numer": "2026619787280727","denom": "2251799813685248"},"maxvolume": "10855.85028615","max_volume_rat": [[1, [3593286463, 1389548]],[1, [0, 128]]],"max_volume_fraction": {"numer": "5968066809508671","denom": "549755813888"},"pubkey": "5a2f1c468b7083c4f7649bf68a50612ffe7c38b1d62e1ece3829ca88e7e7fd12","age": 5,"uuid": "5bff6021-b086-477e-b874-f45d898933fe","is_mine": false}],"numasks": 1,"askdepth": 0,"base": "DOC","rel": "MARTY","timestamp": 1549319941,"netid": 6133}
   ```
 </CollapsibleSection>
 
@@ -366,7 +366,7 @@ Try again this time adding ` | jq` to the end of the `bash` example below:
   	"base": "DOC",
   	"rel": "MARTY",
   	"timestamp": 1549320152,
-  	"netid": 8762
+  	"netid": 6133
   }
   ```
 </CollapsibleSection>

--- a/src/pages/komodo-defi-framework/tutorials/how-to-become-a-liquidity-provider/index.mdx
+++ b/src/pages/komodo-defi-framework/tutorials/how-to-become-a-liquidity-provider/index.mdx
@@ -365,7 +365,7 @@ Display the KMD/LTC Orderbook.
        "is_mine": false
      }
    ],
-   "netid": 8762,
+   "netid": 6133,
    "numasks": 1,
    "numbids": 1,
    "rel": "LTC",
@@ -446,7 +446,7 @@ Display the LTC/KMD Orderbook.
        "is_mine": false
      }
    ],
-   "netid": 8762,
+   "netid": 6133,
    "numasks": 1,
    "numbids": 1,
    "rel": "KMD",

--- a/src/pages/komodo-defi-framework/tutorials/setup-komodefi-api-aws/index.mdx
+++ b/src/pages/komodo-defi-framework/tutorials/setup-komodefi-api-aws/index.mdx
@@ -19,7 +19,7 @@ apt-get install -y unzip jq curl
 wget $(curl --silent https://api.github.com/repos/KomodoPlatform/komodo-defi-framework/releases | jq -r '.[0].assets[] | select(.name | endswith("Linux-Release.zip")).browser_download_url')
 wget https://raw.githubusercontent.com/KomodoPlatform/coins/master/coins
 unzip *Linux-Release.zip
-./kdf "{\"netid\":8762,\"seednodes\":[\"seed01.kmdefi.net\", \"seed02.kmdefi.net\"],\"gui\":\"aws_cli\",\"passphrase\":\"SEED_WORDS_PLEASE_REPLACE\",\"rpc_password\":\"RPC_PASS_PLEASE_REPLACE\",\"myipaddr\":\"0.0.0.0\"}"
+./kdf "{\"netid\":6133,\"seednodes\":[\"seed01.kmdefi.net\", \"seed02.kmdefi.net\"],\"gui\":\"aws_cli\",\"passphrase\":\"SEED_WORDS_PLEASE_REPLACE\",\"rpc_password\":\"RPC_PASS_PLEASE_REPLACE\",\"myipaddr\":\"0.0.0.0\"}"
 ```
 
 ## Install AWS CLI , get AWS access credentials

--- a/src/pages/komodo-defi-framework/tutorials/using-komodefi-cli-in-console/index.mdx
+++ b/src/pages/komodo-defi-framework/tutorials/using-komodefi-cli-in-console/index.mdx
@@ -74,7 +74,7 @@ $ komodefi-cli init
     Config is not set
     Start collecting mm2_cfg into: /home/smk762/komodefi-cli/MM2.json
     > gui is set by default: komodefi-cli
-    > What is the network `kdf` is going to be a part, netid: 8762
+    > What is the network `kdf` is going to be a part, netid: 6133
     > What is the seed phrase: before device quantum scan agent gift sauce flame devote tiny ripple west
     > Allow weak password: No
     > What is the rpc_password: <tb+UD32

--- a/src/pages/start-here/core-technology-discussions/komodo-defi-framework/index.mdx
+++ b/src/pages/start-here/core-technology-discussions/komodo-defi-framework/index.mdx
@@ -113,7 +113,7 @@ There are two parties in an atomic swap: the liquidity provider and the liquidit
 
 The process of an atomic swap begins with the person who makes the initial request.
 
-Taker will need two transactions to perform her swap. One transaction will cover the protocol fee, which is roughly 1/777th the size of the desired order. We call this fee the `<dexfee>`, and its primary purpose is to serve as a disincentive to Taker from spamming the network with rapid requests.
+Taker will need two transactions to perform her swap. One transaction will cover the protocol fee, which is 2% of the desired order (1% when trading GLEEC). We call this fee the `<dexfee>`, and its primary purpose is to serve as a disincentive to Taker from spamming the network with rapid requests.
 
 ### The Atomic Swap Process
 
@@ -165,7 +165,7 @@ Let us now examine what is happening after each step.
 
 #### 1 - Taker Sends `<dexfee>`
 
-If Maker accepts the offer to trade, but does not send `<makerpayment>`, Taker only stands to lose the `<dexfee>`. This is only 1/777th of the entire transaction amount, so she loses very little.
+If Maker accepts the offer to trade, but does not send `<makerpayment>`, Taker only stands to lose the `<dexfee>`. This is only 2% of the entire transaction amount, so she loses very little.
 
 Maker, on the other hand, stands to lose more. Since Maker did not follow through with his end of the bargain, the Komodo DeFi Framework network indicates on his public Komodo DeFi Framework trading profile that he failed in a commitment, thus decreasing his profile’s reputation. If Maker continues this behavior as a habit, he may find it difficult to discover trading partners.
 
@@ -221,7 +221,7 @@ If a user attempts a trade and no response returns from the network, the user sh
 The `<dexfee>` is calculated as the greater of:
 
 *   0.0001 TAKER COIN
-*   1/777th of the order size
+*   2% of the order size (1% when trading GLEEC)
 
 This fee serves multiple purposes:
 


### PR DESCRIPTION
## Summary
- Updates default `netid` from `8762` to `6133` across all config examples, tutorials, and API docs
- Updates DEX fee rate from `1/777th` (~0.13%) to `2%` (1% for GLEEC trades) in buy/sell docs and core technology discussion
- Historical/whitepaper pages left unchanged as they describe the original BarterDEX protocol

Companion to GLEECBTC/komodo-defi-framework#2710

## Test plan
- [ ] Verify docs site builds correctly
- [ ] Spot-check updated pages render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)