### PR TITLE
docs(kdf): document Gnosis Pay card Safe smart_account methods

### DIFF
--- a/src/data/requests/kdf/v2/coin_activation.json
+++ b/src/data/requests/kdf/v2/coin_activation.json
@@ -285,6 +285,34 @@
       "required_confirmations": 5
     }
   },
+  "EnableEthWithTokensSmartAccount": {
+    "userpass": "RPC_UserP@SSW0RD",
+    "method": "enable_eth_with_tokens",
+    "mmrpc": "2.0",
+    "params": {
+      "ticker": "XDAI",
+      "mm2": 1,
+      "swap_contract_address": "0x24abe4c71fc658c91313b6552cd40cd808b3ea80",
+      "fallback_swap_contract": "0x8500afc0bc5214728082163326c2ff0c73f4a871",
+      "nodes": [
+        {
+          "url": "https://rpc.gnosischain.com"
+        },
+        {
+          "url": "https://rpc.gnosis.gateway.fm"
+        }
+      ],
+      "tx_history": true,
+      "erc20_tokens_requests": [
+        {
+          "ticker": "EURE-GNO",
+          "required_confirmations": 4
+        }
+      ],
+      "required_confirmations": 5,
+      "requires_notarization": false
+    }
+  },
   "EnableTendermintWithAssetsBalancesFalse": {
     "method": "enable_tendermint_with_assets",
     "userpass": "RPC_UserP@SSW0RD",

--- a/src/data/sidebar.json
+++ b/src/data/sidebar.json
@@ -714,6 +714,18 @@
           {
             "title": "get_private_keys",
             "href": "/komodo-defi-framework/api/v20/wallet/get_private_keys/"
+          },
+          {
+            "title": "Smart Account Methods Overview",
+            "href": "/komodo-defi-framework/api/v20/wallet/smart_account/"
+          },
+          {
+            "title": "Smart Account: Register",
+            "href": "/komodo-defi-framework/api/v20/wallet/smart_account/register/"
+          },
+          {
+            "title": "Smart Account: Sign Typed Data",
+            "href": "/komodo-defi-framework/api/v20/wallet/smart_account/sign_typed_data/"
           }
         ]
       },

--- a/src/data/tables/common-structures/activation.json
+++ b/src/data/tables/common-structures/activation.json
@@ -153,6 +153,12 @@
         "type": "array",
         "required": false,
         "description": "A list of tokens which were successfully activated. Only included in responses where `get_balances` is `false`"
+      },
+      {
+        "parameter": "smart_account_address",
+        "type": "string",
+        "required": false,
+        "description": "Optional. EVM coins only. The registered Gnosis Pay card Safe for this address's owner EOA. Only present once [smart_account::register](/komodo-defi-framework/api/v20/wallet/smart_account/register/) has succeeded for this exact address in the current session; omitted otherwise."
       }
     ]
   },

--- a/src/data/tables/common-structures/wallet.json
+++ b/src/data/tables/common-structures/wallet.json
@@ -24,6 +24,12 @@
         "type": "object",
         "required": true,
         "description": "A standard [BalanceInfo](/komodo-defi-framework/api/common_structures/wallet/#balance-info) object."
+      },
+      {
+        "parameter": "smart_account_address",
+        "type": "string",
+        "required": false,
+        "description": "Optional. EVM coins only. The registered Gnosis Pay card Safe for this address's owner EOA. Only present once [smart_account::register](/komodo-defi-framework/api/v20/wallet/smart_account/register/) has succeeded for this exact address in the current session; omitted otherwise."
       }
     ]
   },
@@ -68,6 +74,12 @@
         "type": "array",
         "required": false,
         "description": "A list of tokens which were successfully activated. Only included in responses where `get_balances` is `false`"
+      },
+      {
+        "parameter": "smart_account_address",
+        "type": "string",
+        "required": false,
+        "description": "Optional. EVM coins only. The registered Gnosis Pay card Safe for this address's owner EOA. Only present once [smart_account::register](/komodo-defi-framework/api/v20/wallet/smart_account/register/) has succeeded for this exact address in the current session; omitted otherwise."
       }
     ]
   },
@@ -286,6 +298,12 @@
         "type": "string",
         "required": true,
         "description": "`Internal`, or `External`. External is used for addresses that are meant to be visible outside of the wallet (e.g. for receiving payments). Internal is used for addresses which are not meant to be visible outside of the wallet and is used for return transaction change."
+      },
+      {
+        "parameter": "smart_account_address",
+        "type": "string",
+        "required": false,
+        "description": "Optional. EVM coins only. The registered Gnosis Pay card Safe for this address's owner EOA. Only present once [smart_account::register](/komodo-defi-framework/api/v20/wallet/smart_account/register/) has succeeded for this exact address in the current session; omitted otherwise."
       }
     ]
   },

--- a/src/data/tables/v2/wallet.json
+++ b/src/data/tables/v2/wallet.json
@@ -54,5 +54,377 @@
         "description": "An internal server error occurred."
       }
     ]
+  },
+  "SmartAccountRegisterRequest": {
+    "data": [
+      {
+        "parameter": "coin",
+        "type": "string",
+        "required": true,
+        "description": "The ticker of an activated EVM coin or token. The registration is held by this coin's platform coin and is shared with all of its tokens, but not with other platform coins."
+      },
+      {
+        "parameter": "safe_address",
+        "type": "string",
+        "required": true,
+        "description": "The Gnosis Pay card Safe address, as returned by the Gnosis Pay API. Must be [EIP-55](https://eips.ethereum.org/EIPS/eip-55) checksummed: an all-lowercase address containing any of the letters `a`-`f` is rejected with `InvalidSafeAddress`, as is the zero address."
+      },
+      {
+        "parameter": "from",
+        "type": "object",
+        "required": false,
+        "description": "Optional. A standard [WithdrawFromInfo](/komodo-defi-framework/api/common_structures/wallet/#withdraw-from-info) object selecting which owner EOA controls the Safe. Omit it for single-address (Iguana) wallets, where the wallet's only address is used. Required for HD wallets, where omitting it returns `FromAddressRequired`."
+      }
+    ]
+  },
+  "SmartAccountRegisterResponse": {
+    "data": [
+      {
+        "parameter": "coin",
+        "type": "string",
+        "required": true,
+        "description": "The ticker from the request, echoed back."
+      },
+      {
+        "parameter": "owner_address",
+        "type": "string",
+        "required": true,
+        "description": "The owner EOA the card Safe was registered under, in EIP-55 checksummed form. This is the address the on-chain `isOwner` check passed for, and the address whose balance and activation responses will now carry `smart_account_address`."
+      },
+      {
+        "parameter": "smart_account_address",
+        "type": "string",
+        "required": true,
+        "description": "The registered card Safe, in EIP-55 checksummed form. Always the `safe_address` from the request, re-encoded as a checksummed address."
+      }
+    ]
+  },
+  "SmartAccountRegisterErrors": {
+    "data": [
+      {
+        "parameter": "NoSuchCoin",
+        "type": "object",
+        "required": false,
+        "description": "400. The `coin` is not activated. `error_data` carries the requested `coin`."
+      },
+      {
+        "parameter": "NotEthCoin",
+        "type": "object",
+        "required": false,
+        "description": "400. The `coin` is activated but is not an EVM or TRON coin. `error_data` carries the requested `coin`."
+      },
+      {
+        "parameter": "UnsupportedCoinType",
+        "type": "object",
+        "required": false,
+        "description": "400. The `coin` is of a kind card Safes do not apply to: a TRON coin, or an NFT coin. `error_data` carries the requested `coin`."
+      },
+      {
+        "parameter": "InvalidSafeAddress",
+        "type": "object",
+        "required": false,
+        "description": "400. `safe_address` is not a `0x` prefixed 20-byte hex string, fails the EIP-55 checksum (`reason` is then `Invalid address checksum`), or is the zero address (`reason` is `zero address`). `error_data` carries the `reason`."
+      },
+      {
+        "parameter": "FromAddressRequired",
+        "type": "none",
+        "required": false,
+        "description": "400. The wallet is an HD wallet and `from` was omitted, so no single owner address could be resolved. This variant carries no `error_data` field at all."
+      },
+      {
+        "parameter": "InvalidFromAddress",
+        "type": "string",
+        "required": false,
+        "description": "400. `from` was supplied but did not resolve to an address of this wallet, for example an unknown `account_id` or a `derivation_path` whose coin type does not match the coin. `error_data` is the reason, produced by the same address resolver [withdraw](/komodo-defi-framework/api/v20/wallet/tx/withdraw/) uses."
+      },
+      {
+        "parameter": "NotSafeOwner",
+        "type": "object",
+        "required": false,
+        "description": "403. The ownership check completed and the resolved owner address is not an owner of this Safe. `error_data` carries `owner_address` and `safe_address`. Not retryable — either the Safe address or the selected address is wrong."
+      },
+      {
+        "parameter": "OwnerCheckFailed",
+        "type": "string",
+        "required": false,
+        "description": "502. The on-chain ownership check could not be completed, for example because the coin's RPC nodes were unreachable. `error_data` carries the underlying error. Retry with backoff, but bound the retries: the same error is returned when the address does not answer like a Safe at all, which retrying will not fix."
+      }
+    ]
+  },
+  "SmartAccountSignTypedDataRequest": {
+    "data": [
+      {
+        "parameter": "coin",
+        "type": "string",
+        "required": true,
+        "description": "The ticker of an activated EVM coin or token. Must be the coin used for [smart_account::register](/komodo-defi-framework/api/v20/wallet/smart_account/register/), or another token of the same platform coin; the registry is shared across a platform coin and its tokens. The coin's chain id must also equal `domain.chainId`."
+      },
+      {
+        "parameter": "typed_data",
+        "type": "object",
+        "required": true,
+        "description": "The EIP-712 payload returned by Gnosis Pay, in the standard `eth_signTypedData_v4` shape. Its members are documented in the `typed_data` table below. Unknown members at this level are rejected by the dispatcher as `InvalidRequest`."
+      },
+      {
+        "parameter": "from",
+        "type": "object",
+        "required": false,
+        "description": "Optional. A standard [WithdrawFromInfo](/komodo-defi-framework/api/common_structures/wallet/#withdraw-from-info) object selecting which owner EOA signs. Omit it for single-address (Iguana) wallets. Required for HD wallets, where omitting it returns `FromAddressRequired`. The resolved address is also the owner whose registered Safe is looked up."
+      }
+    ]
+  },
+  "Eip712TypedData": {
+    "data": [
+      {
+        "parameter": "types",
+        "type": "object",
+        "required": true,
+        "description": "A map of EIP-712 type name to an array of `{name, type}` field definitions. The entry named by `primaryType` must match the canonical field list exactly, in field names, field types and field order. An `EIP712Domain` entry is optional: when present it must be exactly `chainId` (`uint256`) followed by `verifyingContract` (`address`), and when absent it is inferred from `domain`. Extra entries that no signed type refers to are ignored rather than rejected."
+      },
+      {
+        "parameter": "domain",
+        "type": "object",
+        "required": true,
+        "description": "The EIP-712 domain. It must have exactly two members, `chainId` and `verifyingContract`, both non-null, and nothing else: `name`, `version` and `salt` are rejected with `InvalidTypedData` even though they are standard EIP-712 fields. Key order here is irrelevant; order matters only in the `types.EIP712Domain` entry. Unknown members are rejected."
+      },
+      {
+        "parameter": "primaryType",
+        "type": "string",
+        "required": true,
+        "description": "`SafeTx` or `ModuleTx`. Any other value is rejected with `UnsupportedPrimaryType`."
+      },
+      {
+        "parameter": "message",
+        "type": "object",
+        "required": true,
+        "description": "The values of the `primaryType` fields. `uint256` and `uint8` members accept a `0x` hex string, a decimal string, or a JSON number; `bytes` and `bytes32` members must be `0x` hex strings, never arrays. Extra members here are neither rejected nor hashed, since only the fields declared in `types[primaryType]` are encoded, so a GUI must not treat them as validated."
+      }
+    ]
+  },
+  "SmartAccountSignTypedDataResponse": {
+    "data": [
+      {
+        "parameter": "coin",
+        "type": "string",
+        "required": true,
+        "description": "The ticker from the request, echoed back."
+      },
+      {
+        "parameter": "owner_address",
+        "type": "string",
+        "required": true,
+        "description": "The owner EOA whose key produced `signature`, in EIP-55 checksummed form."
+      },
+      {
+        "parameter": "verifying_contract",
+        "type": "string",
+        "required": true,
+        "description": "The `domain.verifyingContract` from the request, in EIP-55 checksummed form."
+      },
+      {
+        "parameter": "verifying_contract_kind",
+        "type": "string",
+        "required": true,
+        "description": "`registered_safe` when the payload targets the registered card Safe itself (`SafeTx`), or `zodiac_modifier` when it targets a Zodiac modifier verified on-chain to act on that Safe (`ModuleTx`)."
+      },
+      {
+        "parameter": "typed_data_hash",
+        "type": "string",
+        "required": true,
+        "description": "The `0x` prefixed 32-byte EIP-712 digest that was signed, `keccak256(0x1901 || domainSeparator || hashStruct(primaryType, message))`. Both accepted domain dialects hash identically, so the same payload written either way yields the same digest."
+      },
+      {
+        "parameter": "signature",
+        "type": "string",
+        "required": true,
+        "description": "The `0x` prefixed 65-byte owner signature over `typed_data_hash`: 130 hex characters, `r || s || v`, with `v` of `0x1b` or `0x1c` (27 or 28). A plain EOA ECDSA signature, which is what a Safe's `checkSignatures` expects for an owner, not an EIP-1271 contract signature."
+      },
+      {
+        "parameter": "intent",
+        "type": "object",
+        "required": true,
+        "description": "A human-readable summary of what was signed, for GUI confirmation. Its shape depends on `primaryType`: see the `intent (SafeTx)` and `intent (ModuleTx)` tables below."
+      }
+    ]
+  },
+  "SmartAccountIntentSafeTx": {
+    "data": [
+      {
+        "parameter": "type",
+        "type": "string",
+        "required": true,
+        "description": "Always `SafeTx`. Discriminates this intent shape from `ModuleTx`."
+      },
+      {
+        "parameter": "to",
+        "type": "string",
+        "required": true,
+        "description": "The call target, in EIP-55 checksummed form."
+      },
+      {
+        "parameter": "value",
+        "type": "string",
+        "required": true,
+        "description": "The native-token value of the call, as a **decimal** string in the chain's smallest unit, even when the request supplied hex."
+      },
+      {
+        "parameter": "data",
+        "type": "string",
+        "required": true,
+        "description": "The call data, echoed verbatim from `message.data`. KDF does not decode it; a GUI that wants to name the action must decode it itself."
+      },
+      {
+        "parameter": "operation",
+        "type": "string",
+        "required": true,
+        "description": "`CALL` when `message.operation` was `0`, or `DELEGATECALL` when it was `1`. Any other value is rejected with `InvalidTypedData`. `DELEGATECALL` runs the target's code in the Safe's own context and should be surfaced prominently for user confirmation."
+      },
+      {
+        "parameter": "safe_tx_gas",
+        "type": "string",
+        "required": true,
+        "description": "`message.safeTxGas` as a decimal string."
+      },
+      {
+        "parameter": "base_gas",
+        "type": "string",
+        "required": true,
+        "description": "`message.baseGas` as a decimal string."
+      },
+      {
+        "parameter": "gas_price",
+        "type": "string",
+        "required": true,
+        "description": "`message.gasPrice` as a decimal string. `0` means the Safe transaction is relayed without a gas refund."
+      },
+      {
+        "parameter": "gas_token",
+        "type": "string",
+        "required": true,
+        "description": "The token any gas refund is paid in, in EIP-55 checksummed form. The zero address means the chain's native token."
+      },
+      {
+        "parameter": "refund_receiver",
+        "type": "string",
+        "required": true,
+        "description": "The gas-refund recipient, in EIP-55 checksummed form. The zero address means whoever submits the transaction."
+      },
+      {
+        "parameter": "nonce",
+        "type": "string",
+        "required": true,
+        "description": "The Safe transaction nonce as a decimal string. It comes from the Gnosis Pay payload; KDF neither fetches nor validates it, so replay protection is not KDF's responsibility."
+      }
+    ]
+  },
+  "SmartAccountIntentModuleTx": {
+    "data": [
+      {
+        "parameter": "type",
+        "type": "string",
+        "required": true,
+        "description": "Always `ModuleTx`. Discriminates this intent shape from `SafeTx`."
+      },
+      {
+        "parameter": "modifier",
+        "type": "string",
+        "required": true,
+        "description": "The Zodiac modifier the signature authorises, in EIP-55 checksummed form. Always equal to `verifying_contract`, and verified on-chain to act on the registered Safe."
+      },
+      {
+        "parameter": "data",
+        "type": "string",
+        "required": true,
+        "description": "The modifier call data, echoed verbatim from `message.data`. A `ModuleTx` intent has no `to`, `value` or `operation`, so this and `modifier` are the whole of what KDF can tell a GUI about the action."
+      },
+      {
+        "parameter": "salt",
+        "type": "string",
+        "required": true,
+        "description": "The 32-byte `0x` prefixed salt from `message.salt`, echoed verbatim."
+      }
+    ]
+  },
+  "SmartAccountSignTypedDataErrors": {
+    "data": [
+      {
+        "parameter": "NoSuchCoin",
+        "type": "object",
+        "required": false,
+        "description": "400. The `coin` is not activated. `error_data` carries the requested `coin`."
+      },
+      {
+        "parameter": "NotEthCoin",
+        "type": "object",
+        "required": false,
+        "description": "400. The `coin` is activated but is not an EVM or TRON coin. `error_data` carries the requested `coin`."
+      },
+      {
+        "parameter": "UnsupportedCoinType",
+        "type": "object",
+        "required": false,
+        "description": "400. The `coin` is of a kind card Safes do not apply to: a TRON coin, or an NFT coin. `error_data` carries the requested `coin`."
+      },
+      {
+        "parameter": "FromAddressRequired",
+        "type": "none",
+        "required": false,
+        "description": "400. The wallet is an HD wallet and `from` was omitted, so no single owner address could be resolved. This variant carries no `error_data` field at all."
+      },
+      {
+        "parameter": "InvalidFromAddress",
+        "type": "string",
+        "required": false,
+        "description": "400. `from` was supplied but did not resolve to an address of this wallet. `error_data` is the reason, produced by the same address resolver [withdraw](/komodo-defi-framework/api/v20/wallet/tx/withdraw/) uses."
+      },
+      {
+        "parameter": "NoRegisteredSafe",
+        "type": "object",
+        "required": false,
+        "description": "412. No card Safe is registered for the resolved owner EOA. This is a precondition failure rather than a problem with the payload: call [smart_account::register](/komodo-defi-framework/api/v20/wallet/smart_account/register/) for this owner and retry. It is raised before `typed_data` is inspected at all, and it is also what a KDF restart or a coin re-activation produces, since the registry is in-memory. `error_data` carries `owner_address`."
+      },
+      {
+        "parameter": "InvalidTypedData",
+        "type": "string",
+        "required": false,
+        "description": "400. `typed_data` failed validation. Covers a `domain` that is not exactly `{chainId, verifyingContract}`, a `types` entry that does not match the canonical field list, a member that cannot be parsed as its declared type, a `SafeTx` `operation` other than `0` or `1`, and a failure to hash the payload. `error_data` is the specific reason."
+      },
+      {
+        "parameter": "UnsupportedPrimaryType",
+        "type": "string",
+        "required": false,
+        "description": "400. `primaryType` is neither `SafeTx` nor `ModuleTx`. `error_data` is the rejected value."
+      },
+      {
+        "parameter": "ChainIdMismatch",
+        "type": "object",
+        "required": false,
+        "description": "403. `domain.chainId` is not the activated coin's chain id, so the payload is bound to a different chain. `error_data` carries `expected`, a number, the coin's chain id, and `actual`, a string, the value from the payload."
+      },
+      {
+        "parameter": "VerifyingContractNotRegisteredSafe",
+        "type": "object",
+        "required": false,
+        "description": "403. A `SafeTx` whose `domain.verifyingContract` is some contract other than the registered card Safe. `error_data` carries `expected`, the registered Safe, and `actual`, the contract in the payload."
+      },
+      {
+        "parameter": "ModifierNotLinkedToSafe",
+        "type": "object",
+        "required": false,
+        "description": "403. A `ModuleTx` whose modifier's `avatar()` and `target()` views completed but did not both return the registered Safe, so the modifier is not authorised to act on it. `error_data` carries `modifier`, `safe`, `avatar` and `target`, which is enough for a GUI to say which one mismatched. Not retryable."
+      },
+      {
+        "parameter": "OnChainCheckFailed",
+        "type": "string",
+        "required": false,
+        "description": "502. The modifier's `avatar()` or `target()` `eth_call` could not be completed, or did not return an address. `error_data` is the reason. Retryable with backoff; deliberately distinct from `ModifierNotLinkedToSafe` so a flaky RPC node never looks like a security rejection."
+      },
+      {
+        "parameter": "SigningFailed",
+        "type": "string",
+        "required": false,
+        "description": "500. The owner key could not sign the digest. This is also the variant returned for MetaMask, Trezor and WalletConnect activations, whose signing policies this method does not support. `error_data` is the underlying reason. Not retryable."
+      }
+    ]
   }
 }

--- a/src/pages/komodo-defi-framework/api/common_structures/wallet/index.mdx
+++ b/src/pages/komodo-defi-framework/api/common_structures/wallet/index.mdx
@@ -81,6 +81,24 @@ The `AddressInfo` object includes the following items for a given address:
   ```
 </CollapsibleSection>
 
+<CollapsibleSection expandedText="Hide Card Safe Example" collapsedText="Show Card Safe Example">
+  #### Example with a registered card Safe (EVM)
+
+  ```json
+  "0x083C32B38e8050473f6999e22f670d1404235592": {
+      "derivation_method": {
+          "type": "Iguana"
+      },
+      "pubkey": "04ec603f83519cc2150bd99ed0ed6b3f7f029dedff2957cd22542e2504e3d2a7953c084f907cce2f0e26fb0cfc55e06925bf0f88a92b904224dba8ebafdf98ce7b",
+      "balances": {
+          "spendable": "1.25",
+          "unspendable": "0"
+      },
+      "smart_account_address": "0x5aFE000000000000000000000000000000000001"
+  }
+  ```
+</CollapsibleSection>
+
 ### AddressPath
 
 The `AddressPath` object includes the following items:

--- a/src/pages/komodo-defi-framework/api/legacy/my_balance/index.mdx
+++ b/src/pages/komodo-defi-framework/api/legacy/my_balance/index.mdx
@@ -15,12 +15,13 @@ The `my_balance` method returns the current balance of the specified `coin`.
 
 #### Response
 
-| Structure            | Type             | Description                                                                                   |
-| -------------------- | ---------------- | --------------------------------------------------------------------------------------------- |
-| address              | string           | the address that holds the coins                                                              |
-| balance              | string (numeric) | the number of coins in the address; does not include `unspendable_balance`                    |
-| unspendable\_balance | string (numeric) | the `coin` balance that is unspendable at the moment (e.g. if the address has immature UTXOs) |
-| coin                 | string           | the name of the coin                                                                          |
+| Structure               | Type             | Description                                                                                                                                                                                                                                                                             |
+| ----------------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| address                 | string           | the address that holds the coins                                                                                                                                                                                                                                                        |
+| balance                 | string (numeric) | the number of coins in the address; does not include `unspendable_balance`                                                                                                                                                                                                              |
+| unspendable\_balance    | string (numeric) | the `coin` balance that is unspendable at the moment (e.g. if the address has immature UTXOs)                                                                                                                                                                                           |
+| coin                    | string           | the name of the coin                                                                                                                                                                                                                                                                    |
+| smart\_account\_address | string           | Optional. EVM coins only. The registered Gnosis Pay card Safe for this address's owner EOA. Only present once [smart\_account::register](/komodo-defi-framework/api/v20/wallet/smart_account/register/) has succeeded for this exact address in the current session; omitted otherwise. |
 
 #### 📌 Examples
 
@@ -45,6 +46,20 @@ The `my_balance` method returns the current balance of the specified `coin`.
     "balance": "60.00253836",
     "unspendable_balance": "0.1",
     "coin": "HELLOWORLD"
+  }
+  ```
+</CollapsibleSection>
+
+<CollapsibleSection expandedText="Hide Response" collapsedText="Show Response">
+  #### Response (EVM coin with a registered card Safe)
+
+  ```json
+  {
+    "address": "0x083C32B38e8050473f6999e22f670d1404235592",
+    "balance": "0.526",
+    "unspendable_balance": "0",
+    "coin": "XDAI",
+    "smart_account_address": "0x5aFE000000000000000000000000000000000001"
   }
   ```
 </CollapsibleSection>

--- a/src/pages/komodo-defi-framework/api/v20/coin_activation/enable_erc20/index.mdx
+++ b/src/pages/komodo-defi-framework/api/v20/coin_activation/enable_erc20/index.mdx
@@ -30,6 +30,29 @@ The `enable_erc20` method allows you to activate additional ERC20 like tokens of
 }
 ```
 
+## Response (EVM token with a registered card Safe)
+
+`smart_account_address` appears at the top level here, beside `platform_coin` — a contrast with [`enable_eth_with_tokens`](/komodo-defi-framework/api/v20/coin_activation/enable_eth_with_tokens/), which nests the field per address inside `eth_addresses_infos`/`erc20_addresses_infos`. This non-task response only exists for single-address (Iguana) wallets, because it resolves its address via `single_addr_or_err()`; HD wallets activate ERC20 tokens through `task::enable_erc20::init` instead.
+
+```json
+{
+  "mmrpc": "2.0",
+  "result": {
+    "balances": {
+      "0x083C32B38e8050473f6999e22f670d1404235592": {
+        "spendable": "10",
+        "unspendable": "0"
+      }
+    },
+    "platform_coin": "XDAI",
+    "token_contract_address": "0x420ca0f9b9b604ce0fd9c18ef134c705e5fa3430",
+    "required_confirmations": 3,
+    "smart_account_address": "0x5aFE000000000000000000000000000000000001"
+  },
+  "id": null
+}
+```
+
 ## Error - Platform coin is not yet activated
 
 ```json

--- a/src/pages/komodo-defi-framework/api/v20/coin_activation/enable_eth_with_tokens/index.mdx
+++ b/src/pages/komodo-defi-framework/api/v20/coin_activation/enable_eth_with_tokens/index.mdx
@@ -183,6 +183,55 @@ Prior to coin activation using WalletConnect, you need to establish a connection
   ```
 </CollapsibleSection>
 
+#### Request for a coin with a registered card Safe
+
+<CodeGroup title="" tag="POST" label="enable_eth_with_tokens" mm2MethodDecorate="true" source="v2/coin_activation.EnableEthWithTokensSmartAccount" />
+
+<CollapsibleSection expandedText="Hide Response" collapsedText="Show Response">
+  #### Response
+
+  `smart_account_address` is per-address on this method — it is nested inside each owner address's entry in both `eth_addresses_infos` and `erc20_addresses_infos`, rather than appearing once at the top level.
+
+  ```json
+  {
+    "mmrpc": "2.0",
+    "result": {
+        "current_block": 12345678,
+        "eth_addresses_infos": {
+            "0x083C32B38e8050473f6999e22f670d1404235592": {
+                "derivation_method": {
+                    "type": "Iguana"
+                },
+                "pubkey": "04ec603f83519cc2150bd99ed0ed6b3f7f029dedff2957cd22542e2504e3d2a7953c084f907cce2f0e26fb0cfc55e06925bf0f88a92b904224dba8ebafdf98ce7b",
+                "balances": {
+                    "spendable": "0.42",
+                    "unspendable": "0"
+                },
+                "smart_account_address": "0x5aFE000000000000000000000000000000000001"
+            }
+        },
+        "erc20_addresses_infos": {
+            "0x083C32B38e8050473f6999e22f670d1404235592": {
+                "derivation_method": {
+                    "type": "Iguana"
+                },
+                "pubkey": "04ec603f83519cc2150bd99ed0ed6b3f7f029dedff2957cd22542e2504e3d2a7953c084f907cce2f0e26fb0cfc55e06925bf0f88a92b904224dba8ebafdf98ce7b",
+                "balances": {
+                    "EURE-GNO": {
+                        "spendable": "10",
+                        "unspendable": "0"
+                    }
+                },
+                "smart_account_address": "0x5aFE000000000000000000000000000000000001"
+            }
+        },
+        "nfts_infos": {}
+    },
+    "id": null
+  }
+  ```
+</CollapsibleSection>
+
 ### Error Responses
 
 <CollapsibleSection expandedText="Hide Errors" collapsedText="Show Errors">

--- a/src/pages/komodo-defi-framework/api/v20/wallet/smart_account/index.mdx
+++ b/src/pages/komodo-defi-framework/api/v20/wallet/smart_account/index.mdx
@@ -1,0 +1,45 @@
+export const title = "Komodo DeFi Framework Method Overview: Smart Account Methods";
+export const description =
+  "This document provides an overview of the smart account methods, which register and sign for a Gnosis Pay card Safe from the Komodo DeFi Framework.";
+
+# Smart Account Methods Overview
+
+## smart\_account {{label : 'smart_account', tag : 'overview'}}
+
+*   [Register](/komodo-defi-framework/api/v20/wallet/smart_account/register/)
+*   [Sign Typed Data](/komodo-defi-framework/api/v20/wallet/smart_account/sign_typed_data/)
+
+The `smart_account` methods let the Komodo DeFi Framework act for a [Gnosis Pay](https://gnosispay.com/) card [Safe](https://safe.global/) — a smart contract account on Gnosis Chain that holds the funds backing a payment card. Gnosis Pay deploys and operates the Safe; its owner is the EOA whose key KDF holds. KDF is only a **signer and a reader** — it never deploys, configures or broadcasts, and pays no transaction fee. `sign_typed_data` signs only the two payload schemas it recognises, checks them against the registered Safe and the activated chain, and returns a readable `intent` describing what the signature authorises — so a client is never asked to approve an opaque hash.
+
+## The Recurring Flow
+
+Every privileged card operation — setting a spending limit, moving funds out of the Safe, changing an owner — follows the same four steps:
+
+1.  The client asks Gnosis Pay to perform the operation, and the Gnosis Pay API returns an [EIP-712](https://eips.ethereum.org/EIPS/eip-712) typed-data payload describing it.
+2.  The client passes that payload to [smart\_account::sign\_typed\_data](/komodo-defi-framework/api/v20/wallet/smart_account/sign_typed_data/), which validates it and signs its digest with the owner key.
+3.  The client submits the returned signature to Gnosis Pay.
+4.  Gnosis Pay relays the signed operation on-chain.
+
+## Registration Is a Precondition
+
+[smart\_account::register](/komodo-defi-framework/api/v20/wallet/smart_account/register/) must have succeeded for the same owner EOA before `sign_typed_data` will sign anything. Until it has, `sign_typed_data` returns `NoRegisteredSafe` (HTTP 412).
+
+The registration is held in memory and is lost on a KDF restart or a coin re-activation, so `NoRegisteredSafe` means "re-register", not "this user has no card". See [Scope and Lifetime](/komodo-defi-framework/api/v20/wallet/smart_account/register/#scope-and-lifetime).
+
+Once registered, the Safe surfaces as an optional `smart_account_address` field on balance and activation responses for that address — see [AddressInfo](/komodo-defi-framework/api/common_structures/wallet/#address-info) and the other shared address structures. Reading it back is how a client checks whether a registration is currently live:
+
+```json
+{
+  "address": "0x083C32B38e8050473f6999e22f670d1404235592",
+  "balance": "0.526",
+  "unspendable_balance": "0",
+  "coin": "XDAI",
+  "smart_account_address": "0x5aFE000000000000000000000000000000000001"
+}
+```
+
+Its absence means the registration is gone and [smart\_account::register](/komodo-defi-framework/api/v20/wallet/smart_account/register/) must be called again.
+
+<Note type="warning">
+  **Signing needs a locally held key.** `sign_typed_data` signs with a key KDF holds itself, so coins activated through **MetaMask**, **Trezor** or **WalletConnect** cannot use it — it fails with `SigningFailed` (HTTP 500). Only seed-derived activations, single-address (Iguana) and HD, can sign. `register` does not sign and is unaffected. The Gnosis Chain coin must also be activated before either method can be used; the examples on both method pages use `XDAI`, the Gnosis Chain platform coin.
+</Note>

--- a/src/pages/komodo-defi-framework/api/v20/wallet/smart_account/register/index.mdx
+++ b/src/pages/komodo-defi-framework/api/v20/wallet/smart_account/register/index.mdx
@@ -1,0 +1,254 @@
+export const title = "Komodo DeFi Framework Method: Smart Account Register";
+export const description =
+  "The smart_account::register method verifies on-chain that your key owns a Gnosis Pay card Safe, and then tracks the Safe for the current session.";
+
+# Smart Account: Register
+
+## smart\_account::register {{label : 'smart_account::register', tag : 'API-v2'}}
+
+The `smart_account::register` method tells the Komodo DeFi Framework that a Gnosis Pay card Safe belongs to one of your addresses. KDF verifies the claim on-chain before accepting it, and then tracks the Safe so that it appears as `smart_account_address` on balance and activation responses for that address, and so that [smart\_account::sign\_typed\_data](/komodo-defi-framework/api/v20/wallet/smart_account/sign_typed_data/) will sign payloads for it.
+
+Registering does **not** deploy, configure, fund or modify the Safe. Gnosis Pay deploys and operates the Safe server-side; KDF is only a signer and a reader. Nothing is broadcast, and no transaction fee is paid.
+
+<Note>
+  The registration is held in memory and is lost on a KDF restart or a coin re-activation — call this method on **startup**, not only during onboarding. See [Scope and Lifetime](/komodo-defi-framework/api/v20/wallet/smart_account/register/#scope-and-lifetime) below.
+</Note>
+
+## What a Registration Covers
+
+A registration is keyed by the **exact owner EOA** it was made for.
+
+*   `smart_account_address` appears only on responses for that one address. Sibling HD addresses in the same account do not carry it, even though they share a seed.
+*   The same Safe can legitimately be registered under two different owner EOAs, if both pass the `isOwner` check. Two of your addresses may therefore report the same `smart_account_address`. A client that keys card state by Safe address rather than by owner address will collide on this.
+*   Registering an address that already has a registration replaces it. There is no explicit unregister method.
+
+## Scope and Lifetime
+
+The registry is an in-memory cache. After a KDF restart, or after re-activating the platform coin, `smart_account_address` **silently disappears** and [smart\_account::sign\_typed\_data](/komodo-defi-framework/api/v20/wallet/smart_account/sign_typed_data/) returns `NoRegisteredSafe` (HTTP 412). Nothing on-chain is lost; one `register` call restores it.
+
+### Request Parameters
+
+<CompactTable source="v2/wallet.SmartAccountRegisterRequest" />
+
+### Response Parameters
+
+<CompactTable source="v2/wallet.SmartAccountRegisterResponse" />
+
+#### 📌 Examples
+
+<Note type="info">
+  The `error_path` and `error_trace` values below are illustrative.
+</Note>
+
+##### Single-address (Iguana) wallet
+
+<CodeGroup title="Register a card Safe" tag="POST" label="smart_account::register" mm2MethodDecorate="true">
+  ```json
+  {
+    "userpass": "RPC_UserP@SSW0RD",
+    "mmrpc": "2.0",
+    "method": "smart_account::register",
+    "params": {
+      "coin": "XDAI",
+      "safe_address": "0x5aFE000000000000000000000000000000000001"
+    },
+    "id": 0
+  }
+  ```
+</CodeGroup>
+
+<CollapsibleSection expandedText="Hide Register Response" collapsedText="Show Register Response">
+  ### Response (success)
+
+  ```json
+  {
+      "mmrpc": "2.0",
+      "result": {
+          "coin": "XDAI",
+          "owner_address": "0x083C32B38e8050473f6999e22f670d1404235592",
+          "smart_account_address": "0x5aFE000000000000000000000000000000000001"
+      },
+      "id": 0
+  }
+  ```
+</CollapsibleSection>
+
+##### HD wallet
+
+`from` selects which derived address owns the Safe. This example uses the `derivation_path` form; the `account_id` / `chain` / `address_id` form is equally valid here.
+
+<CodeGroup title="Register a card Safe (HD Wallet)" tag="POST" label="smart_account::register" mm2MethodDecorate="true">
+  ```json
+  {
+    "userpass": "RPC_UserP@SSW0RD",
+    "mmrpc": "2.0",
+    "method": "smart_account::register",
+    "params": {
+      "coin": "XDAI",
+      "safe_address": "0x5aFE000000000000000000000000000000000001",
+      "from": {
+        "derivation_path": "m/44'/60'/0'/0/0"
+      }
+    },
+    "id": 1
+  }
+  ```
+</CodeGroup>
+
+<CollapsibleSection expandedText="Hide Register (HD Wallet) Response" collapsedText="Show Register (HD Wallet) Response">
+  ### Response (HD, success)
+
+  ```json
+  {
+      "mmrpc": "2.0",
+      "result": {
+          "coin": "XDAI",
+          "owner_address": "0x083C32B38e8050473f6999e22f670d1404235592",
+          "smart_account_address": "0x5aFE000000000000000000000000000000000001"
+      },
+      "id": 1
+  }
+  ```
+</CollapsibleSection>
+
+### Error Types
+
+<CompactTable source="v2/wallet.SmartAccountRegisterErrors" />
+
+<CollapsibleSection expandedText="Hide Error Responses" collapsedText="Show Error Responses">
+  #### ⚠️ Error Responses
+
+  ##### NoSuchCoin
+
+  ```json
+  {
+      "mmrpc": "2.0",
+      "error": "No such coin: XDAI",
+      "error_path": "smart_account.lp_coins",
+      "error_trace": "smart_account:104] lp_coins:5122]",
+      "error_type": "NoSuchCoin",
+      "error_data": {
+          "coin": "XDAI"
+      },
+      "id": null
+  }
+  ```
+
+  ##### NotEthCoin
+
+  ```json
+  {
+      "mmrpc": "2.0",
+      "error": "Coin 'KMD' is not an EVM/TRON coin",
+      "error_path": "smart_account",
+      "error_trace": "smart_account:107]",
+      "error_type": "NotEthCoin",
+      "error_data": {
+          "coin": "KMD"
+      },
+      "id": null
+  }
+  ```
+
+  ##### UnsupportedCoinType
+
+  Returned for a TRON coin, and for an NFT coin. Neither holds a card Safe's fungible balance.
+
+  ```json
+  {
+      "mmrpc": "2.0",
+      "error": "Gnosis Pay Safe is not supported for this coin type (TRX)",
+      "error_path": "smart_account",
+      "error_trace": "smart_account:112]",
+      "error_type": "UnsupportedCoinType",
+      "error_data": {
+          "coin": "TRX"
+      },
+      "id": null
+  }
+  ```
+
+  ##### InvalidSafeAddress
+
+  An all-lowercase `safe_address`. The zero address produces the same variant with `"reason": "zero address"`.
+
+  ```json
+  {
+      "mmrpc": "2.0",
+      "error": "Invalid Safe address: Invalid address checksum",
+      "error_path": "smart_account",
+      "error_trace": "smart_account:123]",
+      "error_type": "InvalidSafeAddress",
+      "error_data": {
+          "reason": "Invalid address checksum"
+      },
+      "id": null
+  }
+  ```
+
+  ##### FromAddressRequired
+
+  This variant carries no `error_data` field. The wallet is an HD wallet, so `from` must be supplied.
+
+  ```json
+  {
+      "mmrpc": "2.0",
+      "error": "'from' is required to select the owner address for an HD wallet",
+      "error_path": "smart_account.service",
+      "error_trace": "smart_account:132] service:52]",
+      "error_type": "FromAddressRequired",
+      "id": null
+  }
+  ```
+
+  ##### InvalidFromAddress
+
+  `error_data` is the underlying reason from the shared withdraw address resolver — here, an `account_id` that does not exist in this wallet.
+
+  ```json
+  {
+      "mmrpc": "2.0",
+      "error": "Invalid 'from' owner selector: Unknown '3' account",
+      "error_path": "smart_account.service",
+      "error_trace": "smart_account:132] service:44]",
+      "error_type": "InvalidFromAddress",
+      "error_data": "Unknown '3' account",
+      "id": null
+  }
+  ```
+
+  ##### NotSafeOwner
+
+  The ownership check completed and the address is not an owner. Not retryable.
+
+  ```json
+  {
+      "mmrpc": "2.0",
+      "error": "Address 0x083C32B38e8050473f6999e22f670d1404235592 is not an owner of Safe 0x5aFE000000000000000000000000000000000001",
+      "error_path": "smart_account",
+      "error_trace": "smart_account:141]",
+      "error_type": "NotSafeOwner",
+      "error_data": {
+          "owner_address": "0x083C32B38e8050473f6999e22f670d1404235592",
+          "safe_address": "0x5aFE000000000000000000000000000000000001"
+      },
+      "id": null
+  }
+  ```
+
+  ##### OwnerCheckFailed
+
+  The ownership check could not be completed. Retryable with backoff.
+
+  ```json
+  {
+      "mmrpc": "2.0",
+      "error": "On-chain Safe ownership check failed: Transport: All the current rpc nodes are unavailable.",
+      "error_path": "smart_account.service",
+      "error_trace": "smart_account:137] service:70]",
+      "error_type": "OwnerCheckFailed",
+      "error_data": "Transport: All the current rpc nodes are unavailable.",
+      "id": null
+  }
+  ```
+</CollapsibleSection>

--- a/src/pages/komodo-defi-framework/api/v20/wallet/smart_account/sign_typed_data/index.mdx
+++ b/src/pages/komodo-defi-framework/api/v20/wallet/smart_account/sign_typed_data/index.mdx
@@ -1,0 +1,487 @@
+export const title = "Komodo DeFi Framework Method: Smart Account Sign Typed Data";
+export const description =
+  "The smart_account::sign_typed_data method validates a Gnosis Pay card Safe EIP-712 payload and signs it with the owner key held by the Komodo DeFi Framework.";
+
+# Smart Account: Sign Typed Data
+
+## smart\_account::sign\_typed\_data {{label : 'smart_account::sign_typed_data', tag : 'API-v2'}}
+
+The `smart_account::sign_typed_data` method signs an [EIP-712](https://eips.ethereum.org/EIPS/eip-712) payload issued by Gnosis Pay for your card Safe, using the owner key the Komodo DeFi Framework already holds. It validates the payload before signing, and returns both the digest that was signed and a human-readable `intent` describing what the signature authorises.
+
+The method is a pure signer. It does not broadcast anything, does not read or advance the Safe's nonce, and does not change any KDF state. The client takes the returned `signature` back to Gnosis Pay, which relays the operation on-chain.
+
+A card Safe must already be registered for the signing owner EOA with [smart\_account::register](/komodo-defi-framework/api/v20/wallet/smart_account/register/). Until it is, and again after any KDF restart or platform-coin re-activation, this method returns `NoRegisteredSafe` (HTTP 412). See the [Smart Account methods overview](/komodo-defi-framework/api/v20/wallet/smart_account/) for the ownership model and the wallet-type limitation.
+
+## Accepted Schemas
+
+Both schemas are the ones the Gnosis Pay API returns. The `types` entry for the `primaryType` must match one of these exactly, field for field, in the order shown.
+
+`SafeTx` — used for account setup, adding or removing an owner, and executing or withdrawing through the Safe. Its `verifyingContract` is the Safe.
+
+```json
+{
+    "SafeTx": [
+        { "name": "to", "type": "address" },
+        { "name": "value", "type": "uint256" },
+        { "name": "data", "type": "bytes" },
+        { "name": "operation", "type": "uint8" },
+        { "name": "safeTxGas", "type": "uint256" },
+        { "name": "baseGas", "type": "uint256" },
+        { "name": "gasPrice", "type": "uint256" },
+        { "name": "gasToken", "type": "address" },
+        { "name": "refundReceiver", "type": "address" },
+        { "name": "nonce", "type": "uint256" }
+    ]
+}
+```
+
+`ModuleTx` — used for operations routed through a Zodiac Roles or Delay modifier, such as setting a daily limit or spending. Its `verifyingContract` is the modifier.
+
+```json
+{
+    "ModuleTx": [
+        { "name": "data", "type": "bytes" },
+        { "name": "salt", "type": "bytes32" }
+    ]
+}
+```
+
+Both common EIP-712 shapes are accepted — with an explicit `EIP712Domain` entry in `types` (`eth_signTypedData_v4` / MetaMask) and without one (ethers.js) — and both produce the same digest and the same signature. Forward whatever the Gnosis Pay API returns; the two examples below show one of each.
+
+### Request Parameters
+
+<CompactTable source="v2/wallet.SmartAccountSignTypedDataRequest" />
+
+#### typed\_data
+
+<CompactTable source="v2/wallet.Eip712TypedData" />
+
+### Response Parameters
+
+<CompactTable source="v2/wallet.SmartAccountSignTypedDataResponse" />
+
+#### intent (SafeTx)
+
+<CompactTable source="v2/wallet.SmartAccountIntentSafeTx" />
+
+#### intent (ModuleTx)
+
+<CompactTable source="v2/wallet.SmartAccountIntentModuleTx" />
+
+#### 📌 Examples
+
+<Note type="info">
+  The `signature`, `error_path` and `error_trace` values below are illustrative. Each `typed_data_hash` is the real EIP-712 digest of the payload shown immediately above it, and is reproducible with any standard EIP-712 implementation.
+</Note>
+
+##### SafeTx, ERC-20 transfer out of the Safe, `eth_signTypedData_v4` dialect
+
+A single-address (Iguana) wallet signing a Safe transaction that moves 25 units of an 18-decimal ERC-20 token out of the card Safe. `data` is a standard `transfer(address,uint256)` call: the selector `0xa9059cbb`, then the recipient padded to 32 bytes, then the amount padded to 32 bytes.
+
+Addresses inside `typed_data` are not checksum-validated, so lowercase is fine here — unlike `safe_address` on [smart\_account::register](/komodo-defi-framework/api/v20/wallet/smart_account/register/), which must be EIP-55 checksummed.
+
+<CodeGroup title="Sign Typed Data (SafeTx)" tag="POST" label="smart_account::sign_typed_data" mm2MethodDecorate="true">
+  ```json
+  {
+    "userpass": "RPC_UserP@SSW0RD",
+    "mmrpc": "2.0",
+    "method": "smart_account::sign_typed_data",
+    "params": {
+      "coin": "XDAI",
+      "typed_data": {
+        "primaryType": "SafeTx",
+        "domain": {
+          "chainId": "0x64",
+          "verifyingContract": "0x5afe000000000000000000000000000000000001"
+        },
+        "message": {
+          "to": "0x420ca0f9b9b604ce0fd9c18ef134c705e5fa3430",
+          "value": "0x0",
+          "data": "0xa9059cbb000000000000000000000000d00d000000000000000000000000000000000d000000000000000000000000000000000000000000000000015af1d78b58c40000",
+          "operation": "0x0",
+          "safeTxGas": "0x0",
+          "baseGas": "0x0",
+          "gasPrice": "0x0",
+          "gasToken": "0x0000000000000000000000000000000000000000",
+          "refundReceiver": "0x0000000000000000000000000000000000000000",
+          "nonce": "0x5"
+        },
+        "types": {
+          "EIP712Domain": [
+            {
+              "name": "chainId",
+              "type": "uint256"
+            },
+            {
+              "name": "verifyingContract",
+              "type": "address"
+            }
+          ],
+          "SafeTx": [
+            {
+              "name": "to",
+              "type": "address"
+            },
+            {
+              "name": "value",
+              "type": "uint256"
+            },
+            {
+              "name": "data",
+              "type": "bytes"
+            },
+            {
+              "name": "operation",
+              "type": "uint8"
+            },
+            {
+              "name": "safeTxGas",
+              "type": "uint256"
+            },
+            {
+              "name": "baseGas",
+              "type": "uint256"
+            },
+            {
+              "name": "gasPrice",
+              "type": "uint256"
+            },
+            {
+              "name": "gasToken",
+              "type": "address"
+            },
+            {
+              "name": "refundReceiver",
+              "type": "address"
+            },
+            {
+              "name": "nonce",
+              "type": "uint256"
+            }
+          ]
+        }
+      }
+    },
+    "id": 0
+  }
+  ```
+</CodeGroup>
+
+<CollapsibleSection expandedText="Hide Sign Typed Data (SafeTx) Response" collapsedText="Show Sign Typed Data (SafeTx) Response">
+  ### Response (success)
+
+  ```json
+  {
+      "mmrpc": "2.0",
+      "result": {
+          "coin": "XDAI",
+          "owner_address": "0x083C32B38e8050473f6999e22f670d1404235592",
+          "verifying_contract": "0x5aFE000000000000000000000000000000000001",
+          "verifying_contract_kind": "registered_safe",
+          "typed_data_hash": "0x944b2024b5d24154dbc53356cc9aa26ec789e5329d6cae92173d186443633686",
+          "signature": "0x29842a7e0c24c73e2b0a46636cf407a22b406838201488244e2551d1ab249c0f728b34ce2292c136a59193b5a0ed913c819aefd7d913df2a21f67fd0729b22ef1b",
+          "intent": {
+              "type": "SafeTx",
+              "to": "0x420CA0f9B9b604cE0fd9C18EF134C705e5Fa3430",
+              "value": "0",
+              "data": "0xa9059cbb000000000000000000000000d00d000000000000000000000000000000000d000000000000000000000000000000000000000000000000015af1d78b58c40000",
+              "operation": "CALL",
+              "safe_tx_gas": "0",
+              "base_gas": "0",
+              "gas_price": "0",
+              "gas_token": "0x0000000000000000000000000000000000000000",
+              "refund_receiver": "0x0000000000000000000000000000000000000000",
+              "nonce": "5"
+          }
+      },
+      "id": 0
+  }
+  ```
+</CollapsibleSection>
+
+##### ModuleTx, Zodiac modifier call, ethers.js dialect, HD wallet
+
+The dialect Gnosis Pay actually sends: no `EIP712Domain` entry, `domain` in the other field order, and `chainId` as a JSON number. This example picks the signing address on an HD wallet with the `account_id` / `chain` / `address_id` form of `from`.
+
+<CodeGroup title="Sign Typed Data (ModuleTx, HD Wallet)" tag="POST" label="smart_account::sign_typed_data" mm2MethodDecorate="true">
+  ```json
+  {
+    "userpass": "RPC_UserP@SSW0RD",
+    "mmrpc": "2.0",
+    "method": "smart_account::sign_typed_data",
+    "params": {
+      "coin": "XDAI",
+      "from": {
+        "account_id": 0,
+        "chain": "External",
+        "address_id": 1
+      },
+      "typed_data": {
+        "primaryType": "ModuleTx",
+        "domain": {
+          "verifyingContract": "0x20d1ac000000000000000000000000000000002a",
+          "chainId": 100
+        },
+        "message": {
+          "data": "0xa8ec43ee",
+          "salt": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+        },
+        "types": {
+          "ModuleTx": [
+            {
+              "name": "data",
+              "type": "bytes"
+            },
+            {
+              "name": "salt",
+              "type": "bytes32"
+            }
+          ]
+        }
+      }
+    },
+    "id": 1
+  }
+  ```
+</CodeGroup>
+
+<CollapsibleSection expandedText="Hide Sign Typed Data (ModuleTx) Response" collapsedText="Show Sign Typed Data (ModuleTx) Response">
+  ### Response (success)
+
+  ```json
+  {
+      "mmrpc": "2.0",
+      "result": {
+          "coin": "XDAI",
+          "owner_address": "0x083C32B38e8050473f6999e22f670d1404235592",
+          "verifying_contract": "0x20d1aC000000000000000000000000000000002a",
+          "verifying_contract_kind": "zodiac_modifier",
+          "typed_data_hash": "0x3136f800a78d3df8b333b84be999e1f00143345e5401cc1098ab888d8a232955",
+          "signature": "0xc980f14b0f58422a1a29b008d438186a2150ef5f41c3d1d5f0646ce11c3a304f5f8e00866c67d1cffd75a21a0c2d23dbe2294932dc615b170021ccac8e3691621c",
+          "intent": {
+              "type": "ModuleTx",
+              "modifier": "0x20d1aC000000000000000000000000000000002a",
+              "data": "0xa8ec43ee",
+              "salt": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+          }
+      },
+      "id": 1
+  }
+  ```
+</CollapsibleSection>
+
+### Error Types
+
+<CompactTable source="v2/wallet.SmartAccountSignTypedDataErrors" />
+
+<CollapsibleSection expandedText="Hide Error Responses" collapsedText="Show Error Responses">
+  #### ⚠️ Error Responses
+
+  ##### NoSuchCoin
+
+  ```json
+  {
+      "mmrpc": "2.0",
+      "error": "No such coin: XDAI",
+      "error_path": "smart_account.lp_coins",
+      "error_trace": "smart_account:290] lp_coins:5122]",
+      "error_type": "NoSuchCoin",
+      "error_data": {
+          "coin": "XDAI"
+      },
+      "id": null
+  }
+  ```
+
+  ##### NotEthCoin
+
+  ```json
+  {
+      "mmrpc": "2.0",
+      "error": "Coin 'KMD' is not an EVM/TRON coin",
+      "error_path": "smart_account",
+      "error_trace": "smart_account:292]",
+      "error_type": "NotEthCoin",
+      "error_data": {
+          "coin": "KMD"
+      },
+      "id": null
+  }
+  ```
+
+  ##### UnsupportedCoinType
+
+  ```json
+  {
+      "mmrpc": "2.0",
+      "error": "Gnosis Pay Safe is not supported for this coin type (TRX)",
+      "error_path": "smart_account",
+      "error_trace": "smart_account:295]",
+      "error_type": "UnsupportedCoinType",
+      "error_data": {
+          "coin": "TRX"
+      },
+      "id": null
+  }
+  ```
+
+  ##### FromAddressRequired
+
+  This variant carries no `error_data` field. The wallet is an HD wallet, so `from` must be supplied.
+
+  ```json
+  {
+      "mmrpc": "2.0",
+      "error": "'from' is required to select the owner address for an HD wallet",
+      "error_path": "smart_account.service",
+      "error_trace": "smart_account:301] service:52]",
+      "error_type": "FromAddressRequired",
+      "id": null
+  }
+  ```
+
+  ##### InvalidFromAddress
+
+  ```json
+  {
+      "mmrpc": "2.0",
+      "error": "Invalid 'from' owner selector: Unknown '3' account",
+      "error_path": "smart_account.service",
+      "error_trace": "smart_account:301] service:44]",
+      "error_type": "InvalidFromAddress",
+      "error_data": "Unknown '3' account",
+      "id": null
+  }
+  ```
+
+  ##### NoRegisteredSafe
+
+  ```json
+  {
+      "mmrpc": "2.0",
+      "error": "No registered card Safe for owner 0x083C32B38e8050473f6999e22f670d1404235592; call smart_account::register first",
+      "error_path": "smart_account.typed_data",
+      "error_trace": "smart_account:304] typed_data:137]",
+      "error_type": "NoRegisteredSafe",
+      "error_data": {
+          "owner_address": "0x083C32B38e8050473f6999e22f670d1404235592"
+      },
+      "id": null
+  }
+  ```
+
+  ##### InvalidTypedData
+
+  A `domain` carrying a `name` field, which is standard EIP-712 but not part of the canonical Safe domain.
+
+  ```json
+  {
+      "mmrpc": "2.0",
+      "error": "Invalid typed data: domain does not match the canonical schema: expected exactly chainId, verifyingContract",
+      "error_path": "smart_account.typed_data",
+      "error_trace": "smart_account:304] typed_data:143] typed_data:247]",
+      "error_type": "InvalidTypedData",
+      "error_data": "domain does not match the canonical schema: expected exactly chainId, verifyingContract",
+      "id": null
+  }
+  ```
+
+  ##### UnsupportedPrimaryType
+
+  ```json
+  {
+      "mmrpc": "2.0",
+      "error": "Unsupported primaryType 'Permit': expected SafeTx or ModuleTx",
+      "error_path": "smart_account.typed_data",
+      "error_trace": "smart_account:304] typed_data:177]",
+      "error_type": "UnsupportedPrimaryType",
+      "error_data": "Permit",
+      "id": null
+  }
+  ```
+
+  ##### ChainIdMismatch
+
+  ```json
+  {
+      "mmrpc": "2.0",
+      "error": "chainId mismatch: coin is 100, typed data is 1",
+      "error_path": "smart_account.typed_data",
+      "error_trace": "smart_account:304] typed_data:150]",
+      "error_type": "ChainIdMismatch",
+      "error_data": {
+          "expected": 100,
+          "actual": "1"
+      },
+      "id": null
+  }
+  ```
+
+  ##### VerifyingContractNotRegisteredSafe
+
+  ```json
+  {
+      "mmrpc": "2.0",
+      "error": "verifyingContract 0xD00D000000000000000000000000000000000D00 is not the registered card Safe 0x5aFE000000000000000000000000000000000001",
+      "error_path": "smart_account.typed_data",
+      "error_trace": "smart_account:304] typed_data:161]",
+      "error_type": "VerifyingContractNotRegisteredSafe",
+      "error_data": {
+          "expected": "0x5aFE000000000000000000000000000000000001",
+          "actual": "0xD00D000000000000000000000000000000000D00"
+      },
+      "id": null
+  }
+  ```
+
+  ##### ModifierNotLinkedToSafe
+
+  Here `avatar()` returned the registered Safe but `target()` returned something else — a chained modifier, which is rejected.
+
+  ```json
+  {
+      "mmrpc": "2.0",
+      "error": "Modifier 0x20d1aC000000000000000000000000000000002a is not verified on-chain to act on the registered Safe 0x5aFE000000000000000000000000000000000001: avatar() = 0x5aFE000000000000000000000000000000000001, target() = 0xD00D000000000000000000000000000000000D00",
+      "error_path": "smart_account.typed_data",
+      "error_trace": "smart_account:304] typed_data:172] typed_data:341]",
+      "error_type": "ModifierNotLinkedToSafe",
+      "error_data": {
+          "modifier": "0x20d1aC000000000000000000000000000000002a",
+          "safe": "0x5aFE000000000000000000000000000000000001",
+          "avatar": "0x5aFE000000000000000000000000000000000001",
+          "target": "0xD00D000000000000000000000000000000000D00"
+      },
+      "id": null
+  }
+  ```
+
+  ##### OnChainCheckFailed
+
+  ```json
+  {
+      "mmrpc": "2.0",
+      "error": "On-chain modifier check failed: avatar() on 0x20d1aC000000000000000000000000000000002a failed: Transport: All the current rpc nodes are unavailable.",
+      "error_path": "smart_account.typed_data",
+      "error_trace": "smart_account:304] typed_data:172] typed_data:369]",
+      "error_type": "OnChainCheckFailed",
+      "error_data": "avatar() on 0x20d1aC000000000000000000000000000000002a failed: Transport: All the current rpc nodes are unavailable.",
+      "id": null
+  }
+  ```
+
+  ##### SigningFailed
+
+  The response for an activation whose key KDF does not hold. MetaMask, Trezor and WalletConnect activations all fail here. The `error` text is an internal message and may change between releases — match on `error_type`, not on its wording.
+
+  ```json
+  {
+      "mmrpc": "2.0",
+      "error": "Signing failed: Internal error: Unsupported method: `activated_key_or_err` is supported only for `PrivKeyPolicy::KeyPair` or `PrivKeyPolicy::HDWallet`",
+      "error_path": "smart_account.typed_data.eth",
+      "error_trace": "smart_account:304] typed_data:186] eth:3474]",
+      "error_type": "SigningFailed",
+      "error_data": "Internal error: Unsupported method: `activated_key_or_err` is supported only for `PrivKeyPolicy::KeyPair` or `PrivKeyPolicy::HDWallet`",
+      "id": null
+  }
+  ```
+</CollapsibleSection>

--- a/src/pages/komodo-defi-framework/api/v20/wallet/task_managed/account_balance/index.mdx
+++ b/src/pages/komodo-defi-framework/api/v20/wallet/task_managed/account_balance/index.mdx
@@ -150,6 +150,72 @@ Use the `task::account_balance::status` method to view the status / response of 
   ```
 </CollapsibleSection>
 
+<CollapsibleSection expandedText="Hide Response" collapsedText="Show Response">
+  #### Response (EVM HD coin with registered card Safes)
+
+  Two of the three addresses below carry `smart_account_address`; the third omits it. This is not
+  one registration covering the account — the smart account registry keys on the exact address, so
+  this response implies **two separate `smart_account::register` calls** (one per address that
+  shows the field), not a single account-wide registration.
+
+  ```json
+  {
+    "mmrpc": "2.0",
+    "result": {
+      "status": "Ok",
+      "details": {
+        "account_index": 0,
+        "derivation_path": "m/44'/60'/0'",
+        "total_balance": {
+          "XDAI": {
+            "spendable": "1.25",
+            "unspendable": "0"
+          }
+        },
+        "addresses": [
+          {
+            "address": "0x083C32B38e8050473f6999e22f670d1404235592",
+            "derivation_path": "m/44'/60'/0'/0/0",
+            "chain": "External",
+            "balance": {
+              "XDAI": {
+                "spendable": "0.5",
+                "unspendable": "0"
+              }
+            },
+            "smart_account_address": "0x5aFE000000000000000000000000000000000001"
+          },
+          {
+            "address": "0xb0B0000000000000000000000000000000000b01",
+            "derivation_path": "m/44'/60'/0'/0/1",
+            "chain": "External",
+            "balance": {
+              "XDAI": {
+                "spendable": "0.75",
+                "unspendable": "0"
+              }
+            },
+            "smart_account_address": "0x5aFE000000000000000000000000000000000001"
+          },
+          {
+            "address": "0xC0DE000000000000000000000000000000000c02",
+            "derivation_path": "m/44'/60'/0'/0/2",
+            "chain": "External",
+            "balance": {
+              "XDAI": {
+                "spendable": "0",
+                "unspendable": "0"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "id": null
+  }
+  ```
+</CollapsibleSection>
+
 ## task::account\_balance::cancel {{label : 'task::account_balance::cancel', tag : 'API-v2'}}
 
 Use the `task::account_balance::cancel` method to cancel an account balance request.


### PR DESCRIPTION
Documents the two new `smart_account::` RPCs from KDF, and the optional `smart_account_address` field they surface on existing balance and activation responses.

**New pages** under `v20/wallet/smart_account/`: an overview, `register`, and `sign_typed_data` (both accepted schemas, worked SafeTx and ModuleTx examples, all 13 errors).

**Existing pages**: `smart_account_address` added to the three shared address structures, plus additive examples on `my_balance`, `account_balance`, `enable_eth_with_tokens` and `enable_erc20` — the field is per-address on some methods and top-level on others, so each placement is shown.

Examples use `XDAI` and `EURE-GNO`; Safe and modifier addresses are deliberately synthetic. Both published `typed_data_hash` values are the real EIP-712 digests of the payloads shown.

### Notes for review

- **Conflicts with #601** on the three `common-structures/wallet.json` `data` arrays and the `my_balance` table. Rows were appended at the end of each array so the resolution is "keep both".